### PR TITLE
adds sample k8s manifests and updates readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ node-drainer --access-key-id example_id --secret-access-key example_secret --reg
 
 ## Installation
 
-Binaries and packages are not provided for *node-drainer*. To have it installed one must compile it from source.
+* Binaries for *node-drainer* are provided for each release [here](https://github.com/rebuy-de/node-drainer/releases).
+* Docker containers are are provided [here](https://quay.io/repository/rebuy/node-drainer). To obtain the latest docker image run `docker pull quay.io/rebuy/node-drainer:master`.
+* For deploying *node-drainer* docker image to your Kubernetes cluster you can use the sample manifest files (found [here](https://github.com/rebuy-de/node-drainer/tree/master/samples)), just remember to fill in your own AWS credentials. I you use RBAC in Kubernetes you can also take advantage of the sample service account configuration.
 
 To compile *node-drainer* from source you need a working
 [Golang](https://golang.org/doc/install) development environment. The sources

--- a/pkg/sqs/test_util/fixture_generators.go
+++ b/pkg/sqs/test_util/fixture_generators.go
@@ -9,8 +9,6 @@ import (
 	"github.com/rebuy-de/node-drainer/pkg/util"
 )
 
-//TODO: anonymise
-
 func GenerateDescribeInstancesOutput(empty bool) *ec2.DescribeInstancesOutput {
 	output := &ec2.DescribeInstancesOutput{}
 	reservation := &ec2.Reservation{}

--- a/samples/deployment.yaml
+++ b/samples/deployment.yaml
@@ -1,0 +1,48 @@
+# Example K8S Deployment manifest file, read before applying
+apiVersion: extensions/v1beta1
+kind: Deployment
+
+metadata:
+  name: node-drainer
+  labels:
+    app: node-drainer
+
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+
+  # You should always have one replica only,
+  # node-drainer was not designed to run concurrently
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+
+  template:
+    metadata:
+      name: node-drainer
+      labels:
+        app: node-drainer
+
+    spec:
+      # The service account is necessary if your K8S cluster is running RBAC,
+      # otherwise the following line should be deleted
+      serviceAccountName: node-drainer
+
+      containers:
+      - name: node-drainer
+        image: "quay.io/rebuy/node-drainer:master"
+        imagePullPolicy: Always
+        # These are sample arguments, configure before applying the manifest
+        args:
+        - -q=asg-shutdown-queue
+        - -r=eu-west-1
+        - --access-key-id=FILL-ME-IN
+        - --secret-access-key=FILL-ME-IN
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi

--- a/samples/serviceaccount.yaml
+++ b/samples/serviceaccount.yaml
@@ -1,0 +1,38 @@
+# Example service account K8S manifest file, read before applying
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-drainer
+---
+# ClusterRole is necessary for node-drainer to read node information
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-drainer
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch", "get", "update"]
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "delete", "get"]
+- apiGroups: [""]
+  resources:
+  - pods/eviction
+  verbs: ["list", "get", "create"]
+---
+# We must bind the ClusterRole to our new ServiceAccount
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-drainer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-drainer
+subjects:
+- kind: ServiceAccount
+  name: node-drainer
+  namespace: default


### PR DESCRIPTION
readme is updated with correct installation information
- binary downloads
- docker image download

samples folder was added, hosting sample kubernetes manifest files for
configuring node-drainer inside a k8s cluster

@rebuy-de/prp-node-drainer please review