### PR TITLE
Fix message body logging

### DIFF
--- a/pkg/sqs/sqs.go
+++ b/pkg/sqs/sqs.go
@@ -93,10 +93,10 @@ func (mh *MessageHandler) handleMessage(msg *sqs.ReceiveMessageOutput) {
 	}
 
 	for m := range msg.Messages {
+		log.Debugf("Message body: %s", string(*msg.Messages[m].Body))
+
 		var message util.Message
 		err := json.Unmarshal([]byte(*msg.Messages[m].Body), &message)
-
-		log.Debugf("Message body: ", message)
 
 		messageHandle := msg.Messages[m].ReceiptHandle
 


### PR DESCRIPTION
I forgot that logging a struct with pointers will print the pointer addresses, which i don't care about :wink:. 
So let's just print the unparsed message body.
@rebuy-de/prp-node-drainer 