### PR TITLE
CLOUD-2323 Add instrumentation

### DIFF
--- a/cmd/inst.go
+++ b/cmd/inst.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rebuy-de/node-drainer/v2/pkg/instutil"
+	"github.com/rebuy-de/node-drainer/v2/pkg/integration/aws"
+	"github.com/rebuy-de/node-drainer/v2/pkg/integration/aws/ec2"
+	"github.com/rebuy-de/rebuy-go-sdk/v2/pkg/logutil"
+)
+
+const (
+	metricMainLoopIterations       = "mainloop_iterations_total"
+	metricMainLoopDrainDuration    = "mainloop_drain_duration"
+	metricMainLoopPendingInstances = "mainloop_pending_instances"
+)
+
+type metrics struct {
+	mainloopIteration prometheus.Counter
+}
+
+func InitIntrumentation(ctx context.Context) context.Context {
+	ctx = instutil.NewCounter(ctx, metricMainLoopIterations)
+	ctx = instutil.NewGauge(ctx, metricMainLoopPendingInstances)
+	ctx = instutil.NewHistogram(ctx, metricMainLoopDrainDuration,
+		instutil.BucketScale(60, 1, 2, 3, 5, 8, 13, 21, 34)...)
+	return ctx
+}
+
+func InstMainLoopStarted(ctx context.Context, instances aws.Instances) {
+	c, ok := instutil.Counter(ctx, metricMainLoopIterations)
+	if ok {
+		c.Inc()
+	}
+
+	g, ok := instutil.Gauge(ctx, metricMainLoopPendingInstances)
+	if ok {
+		// Note: In the future this should track all instances that have a
+		// lifecycle message and are not completed yet. But since we are now
+		// still watching the old node-drainer, this schould be fine.
+		g.Set(float64(len(instances.
+			Select(aws.HasEC2State(ec2.InstanceStateRunning)).
+			Select(aws.HasLifecycleMessage),
+		)))
+	}
+
+}
+
+func InstMainLoopCompletingInstance(ctx context.Context, instance aws.Instance) {
+	logutil.Get(ctx).
+		WithFields(logFieldsFromStruct(instance)).
+		Info("marking node as complete")
+}
+
+func InstMainLoopInstanceStateChanged(ctx context.Context, instance aws.Instance, prevState, currState string) {
+	logger := logutil.Get(ctx).
+		WithFields(logFieldsFromStruct(instance))
+
+	logger.Infof("instance state changed from '%s' to '%s'", prevState, currState)
+
+	if currState == ec2.InstanceStateTerminated {
+		duration := instance.EC2.TerminationTime.Sub(instance.ASG.TriggeredAt)
+		logger.Infof("instance drainage took %v", duration)
+
+		m, ok := instutil.Histogram(ctx, metricMainLoopDrainDuration)
+		if ok {
+			m.Observe(duration.Seconds())
+		}
+	}
+}
+
+func InstMainLoopDeletingLifecycleMessage(ctx context.Context, instance aws.Instance) {
+	logutil.Get(ctx).
+		WithFields(logFieldsFromStruct(instance)).
+		Info("deleting lifecycle message from SQS")
+}
+
+func InstMainLoopDeletingLifecycleMessageAgeSanityCheckFailed(ctx context.Context, instance aws.Instance, age time.Duration) {
+	logutil.Get(ctx).
+		WithFields(logFieldsFromStruct(instance)).
+		Warnf("termination time of %s was triggered just %v ago, assuming that the cache was empty",
+			instance.InstanceID, age)
+}

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -32,6 +32,8 @@ func (r *Runner) Bind(cmd *cobra.Command) error {
 }
 
 func (r *Runner) Run(ctx context.Context, cmd *cobra.Command, args []string) {
+	ctx = InitIntrumentation(ctx)
+
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 		Profile:           r.awsProfile,

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.6.0
+	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/rebuy-de/rebuy-go-sdk/v2 v2.4.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.6

--- a/pkg/instutil/instutil.go
+++ b/pkg/instutil/instutil.go
@@ -1,0 +1,98 @@
+package instutil
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rebuy-de/rebuy-go-sdk/v2/pkg/cmdutil"
+	"github.com/rebuy-de/rebuy-go-sdk/v2/pkg/logutil"
+)
+
+type contextKeyCounter string
+type contextKeyHistogram string
+type contextKeyGauge string
+
+var namespace string
+
+func init() {
+	re := regexp.MustCompile("[^a-zA-Z0-9]+")
+	n := re.ReplaceAllString(cmdutil.Name, "")
+	namespace = strings.ToLower(n)
+}
+
+func NewCounter(ctx context.Context, name string) context.Context {
+	metric := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      name,
+	})
+	err := prometheus.Register(metric)
+	if err != nil {
+		logutil.Get(ctx).
+			WithError(errors.WithStack(err)).
+			Errorf("failed to register counter with name '%s'", name)
+	}
+	return context.WithValue(ctx, contextKeyCounter(name), metric)
+}
+
+func Counter(ctx context.Context, name string) (prometheus.Counter, bool) {
+	metric, ok := ctx.Value(contextKeyCounter(name)).(prometheus.Counter)
+	if !ok {
+		logutil.Get(ctx).Warnf("counter with name '%s' not found", name)
+	}
+	return metric, ok
+}
+
+func BucketScale(factor float64, values ...float64) []float64 {
+	for i := range values {
+		values[i] = values[i] * factor
+	}
+	return values
+}
+
+func NewHistogram(ctx context.Context, name string, buckets ...float64) context.Context {
+	metric := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      name,
+		Buckets:   buckets,
+	})
+	err := prometheus.Register(metric)
+	if err != nil {
+		logutil.Get(ctx).
+			WithError(errors.WithStack(err)).
+			Errorf("failed to register histogram with name '%s'", name)
+	}
+	return context.WithValue(ctx, contextKeyHistogram(name), metric)
+}
+
+func Histogram(ctx context.Context, name string) (prometheus.Histogram, bool) {
+	metric, ok := ctx.Value(contextKeyHistogram(name)).(prometheus.Histogram)
+	if !ok {
+		logutil.Get(ctx).Warnf("histogram with name '%s' not found", name)
+	}
+	return metric, ok
+}
+
+func NewGauge(ctx context.Context, name string) context.Context {
+	metric := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      name,
+	})
+	err := prometheus.Register(metric)
+	if err != nil {
+		logutil.Get(ctx).
+			WithError(errors.WithStack(err)).
+			Errorf("failed to register gauge with name '%s'", name)
+	}
+	return context.WithValue(ctx, contextKeyGauge(name), metric)
+}
+
+func Gauge(ctx context.Context, name string) (prometheus.Gauge, bool) {
+	metric, ok := ctx.Value(contextKeyGauge(name)).(prometheus.Gauge)
+	if !ok {
+		logutil.Get(ctx).Warnf("gauge with name '%s' not found", name)
+	}
+	return metric, ok
+}

--- a/pkg/integration/aws/filters.go
+++ b/pkg/integration/aws/filters.go
@@ -49,3 +49,15 @@ func HasASGData(i *Instance) bool {
 func HasLifecycleMessage(i *Instance) bool {
 	return HasASGData(i) && i.ASG.Deleted == false
 }
+
+func HasEC2State(states ...string) Selector {
+	return func(i *Instance) bool {
+		for _, state := range states {
+			if i.EC2.State == state {
+				return true
+			}
+		}
+
+		return false
+	}
+}


### PR DESCRIPTION
> https://jira.rebuy.de/browse/CLOUD-2323

Adds new `instutil` package which roughly works the same manner as `logutil` does. It has the advantage that it is easy to split instumentation code into other functions without having to carry the metrics around.

Gives a nice, but boring [graph](https://grafana.production.rebuy.cloud/d/yoV9RZ_iz/node-drainer?orgId=1&from=now-3h&to=now&refresh=1m):

![Screenshot 2020-06-05 16:41:06](https://user-images.githubusercontent.com/1698599/83889479-7bd27f80-a74b-11ea-9d80-51ff99eb8139.png)
