### PR TITLE
CLOUD-2364 Collect spot-instance data

### DIFF
--- a/cmd/inst.go
+++ b/cmd/inst.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rebuy-de/node-drainer/v2/pkg/instutil"
 	"github.com/rebuy-de/node-drainer/v2/pkg/integration/aws"
 	"github.com/rebuy-de/node-drainer/v2/pkg/integration/aws/ec2"
+	"github.com/rebuy-de/node-drainer/v2/pkg/logutilbeta"
 	"github.com/rebuy-de/rebuy-go-sdk/v2/pkg/logutil"
 )
 
@@ -50,13 +51,13 @@ func InstMainLoopStarted(ctx context.Context, instances aws.Instances) {
 
 func InstMainLoopCompletingInstance(ctx context.Context, instance aws.Instance) {
 	logutil.Get(ctx).
-		WithFields(logFieldsFromStruct(instance)).
+		WithFields(logutilbeta.FromStruct(instance)).
 		Info("marking node as complete")
 }
 
 func InstMainLoopInstanceStateChanged(ctx context.Context, instance aws.Instance, prevState, currState string) {
 	logger := logutil.Get(ctx).
-		WithFields(logFieldsFromStruct(instance))
+		WithFields(logutilbeta.FromStruct(instance))
 
 	logger.Infof("instance state changed from '%s' to '%s'", prevState, currState)
 
@@ -73,13 +74,13 @@ func InstMainLoopInstanceStateChanged(ctx context.Context, instance aws.Instance
 
 func InstMainLoopDeletingLifecycleMessage(ctx context.Context, instance aws.Instance) {
 	logutil.Get(ctx).
-		WithFields(logFieldsFromStruct(instance)).
+		WithFields(logutilbeta.FromStruct(instance)).
 		Info("deleting lifecycle message from SQS")
 }
 
 func InstMainLoopDeletingLifecycleMessageAgeSanityCheckFailed(ctx context.Context, instance aws.Instance, age time.Duration) {
 	logutil.Get(ctx).
-		WithFields(logFieldsFromStruct(instance)).
+		WithFields(logutilbeta.FromStruct(instance)).
 		Warnf("termination time of %s was triggered just %v ago, assuming that the cache was empty",
 			instance.InstanceID, age)
 }

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -5,10 +5,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rebuy-de/rebuy-go-sdk/v2/pkg/cmdutil"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
@@ -67,23 +65,4 @@ func (r *Runner) Run(ctx context.Context, cmd *cobra.Command, args []string) {
 		return errors.Wrap(mainLoop.Run(ctx), "failed to run main loop")
 	})
 	cmdutil.Must(egrp.Wait())
-}
-
-// Canidate for SDK
-func logFieldsFromStruct(s interface{}) logrus.Fields {
-	fields := logrus.Fields{}
-	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		TagName: "logfield",
-		Result:  &fields,
-	})
-	if err != nil {
-		return logrus.Fields{"logfield-error": err}
-	}
-
-	err = dec.Decode(s)
-	if err != nil {
-		return logrus.Fields{"logfield-error": err}
-	}
-
-	return fields
 }

--- a/cmd/templates/status.html
+++ b/cmd/templates/status.html
@@ -64,6 +64,42 @@
           </tbody>
         </table>
 
+        <h3>Spot Requests</h3>
+
+        <table class="table table-hover table-sm table-wide">
+          <thead>
+            <tr>
+              <th>Instance ID</th>
+              <th>Request ID</th>
+              <th>Create Time</th>
+              <th>State</th>
+              <th>Status Code</th>
+              <th>Status Update Time</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{ range .SpotInstances }}
+              <tr>
+                <td>{{ .InstanceID }}</td>
+                <td>{{ .RequestID }}</td>
+                <td>{{ PrettyTime .CreateTime }}</td>
+                <td>
+                    {{ if eq .State "active" }}
+                        <span class="badge badge-success">Active</span>
+                    {{ else if eq .State "closed" }}
+                        <span class="badge badge-danger">Closed</span>
+                    {{ else }}
+                        <code>{{ .State }}</code>
+                    {{ end }}
+                </td>
+                <td><code>{{ .StatusCode }}</code></td>
+                <td>{{ PrettyTime .StatusUpdateTime }}</td>
+              </tr>
+            {{ end }}
+          </tbody>
+        </table>
+
+
         <h3>ASG Lifecycle</h3>
 
         <table class="table table-hover table-sm table-wide">

--- a/pkg/integration/aws/asg/asg.go
+++ b/pkg/integration/aws/asg/asg.go
@@ -55,13 +55,13 @@ type Instance struct {
 	ID string `logfield:"instance-id"`
 
 	// TriggeredAt is the thime then the shutdown was triggered.
-	TriggeredAt time.Time `logfield:"triggered-at"`
+	TriggeredAt time.Time `logfield:"lifecycle-triggered-at"`
 
 	// Completed indicates that Complete() was called.
-	Completed bool `logfield:"completed"`
+	Completed bool `logfield:"lifecycle-completed"`
 
 	// Deleted indicates that Delete() was called.
-	Deleted bool `logfield:"deleted"`
+	Deleted bool `logfield:"lifecycle-deleted"`
 }
 
 type cacheValue struct {
@@ -210,10 +210,10 @@ func (h *handler) handle(ctx context.Context, message *sqs.Message) error {
 	}
 
 	ctx = logutil.WithFields(ctx, logrus.Fields{
-		"asg_name":     cacheItem.Body.AutoScalingGroupName,
-		"message_time": cacheItem.Body.Time,
+		"asg-name":     cacheItem.Body.AutoScalingGroupName,
+		"message-time": cacheItem.Body.Time,
 		"transistion":  cacheItem.Body.LifecycleTransition,
-		"instance_id":  cacheItem.Body.EC2InstanceId,
+		"instance-id":  cacheItem.Body.EC2InstanceId,
 	})
 
 	if cacheItem.Body.Event == "autoscaling:TEST_NOTIFICATION" {

--- a/pkg/integration/aws/combine.go
+++ b/pkg/integration/aws/combine.go
@@ -3,10 +3,11 @@ package aws
 import (
 	"github.com/rebuy-de/node-drainer/v2/pkg/integration/aws/asg"
 	"github.com/rebuy-de/node-drainer/v2/pkg/integration/aws/ec2"
+	"github.com/rebuy-de/node-drainer/v2/pkg/integration/aws/spot"
 )
 
 // CombineInstances merges EC2 instance date from different sources.
-func CombineInstances(ai []asg.Instance, ei []ec2.Instance) Instances {
+func CombineInstances(ai []asg.Instance, ei []ec2.Instance, si []spot.Instance) Instances {
 	instances := map[string]Instance{}
 
 	for _, i := range ai {
@@ -26,6 +27,16 @@ func CombineInstances(ai []asg.Instance, ei []ec2.Instance) Instances {
 		combined := instances[i.InstanceID]
 		combined.InstanceID = i.InstanceID
 		combined.EC2 = i
+		instances[i.InstanceID] = combined
+	}
+
+	for _, i := range si {
+		// It returns the empty value, if the key does not exist yet. Therefore
+		// we do not need any checks whether the instances is already in the
+		// map and just need to set the Instance ID.
+		combined := instances[i.InstanceID]
+		combined.InstanceID = i.InstanceID
+		combined.Spot = i
 		instances[i.InstanceID] = combined
 	}
 

--- a/pkg/integration/aws/ec2/ec2.go
+++ b/pkg/integration/aws/ec2/ec2.go
@@ -25,16 +25,15 @@ const (
 
 // Instance is the instance-related data that is retrieved via API.
 type Instance struct {
-	InstanceID           string     `logfield:"instance-id"`
-	InstanceName         string     `logfield:"instance-name"`
-	HostName             string     `logfield:"node-name"`
-	InstanceType         string     `logfield:"instance-type"`
-	AutoScalingGroupName string     `logfield:"autoscaling-group-name"`
-	AvailabilityZone     string     `logfield:"availability-zone"`
-	InstanceLifecycle    string     `logfield:"instance-lifecycle"`
-	State                string     `logfield:"instance-state"`
-	LaunchTime           time.Time  `logfield:"launch-time"`
-	TerminationTime      *time.Time `logfield:"termination-time,omitempty"`
+	InstanceID        string     `logfield:"instance-id"`
+	InstanceName      string     `logfield:"instance-name"`
+	HostName          string     `logfield:"node-name"`
+	InstanceType      string     `logfield:"instance-type"`
+	AvailabilityZone  string     `logfield:"availability-zone"`
+	InstanceLifecycle string     `logfield:"ec2-instance-lifecycle"`
+	State             string     `logfield:"ec2-instance-state"`
+	LaunchTime        time.Time  `logfield:"ec2-launch-time"`
+	TerminationTime   *time.Time `logfield:"ec2-termination-time,omitempty"`
 }
 
 // Changed returns true, if relevant fields of the instance changed.

--- a/pkg/integration/aws/ec2/ec2.go
+++ b/pkg/integration/aws/ec2/ec2.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/pkg/errors"
 
+	"github.com/rebuy-de/node-drainer/v2/pkg/logutilbeta"
 	"github.com/rebuy-de/node-drainer/v2/pkg/syncutil"
 	"github.com/rebuy-de/rebuy-go-sdk/v2/pkg/logutil"
 )
@@ -141,7 +142,7 @@ func (s *store) runOnce(ctx context.Context) error {
 		old, ok := s.cache[instance.InstanceID]
 		if !ok {
 			logutil.Get(ctx).
-				WithFields(logFieldsFromStruct(instance)).
+				WithFields(logutilbeta.FromStruct(instance)).
 				Debugf("add new instance to cache")
 			changed = true
 			continue
@@ -149,7 +150,7 @@ func (s *store) runOnce(ctx context.Context) error {
 
 		if instance.Changed(old) {
 			logutil.Get(ctx).
-				WithFields(logFieldsFromStruct(instance)).
+				WithFields(logutilbeta.FromStruct(instance)).
 				Debugf("cached instance changed")
 			changed = true
 			continue
@@ -161,7 +162,7 @@ func (s *store) runOnce(ctx context.Context) error {
 		_, ok := instances[instance.InstanceID]
 		if !ok {
 			logutil.Get(ctx).
-				WithFields(logFieldsFromStruct(instance)).
+				WithFields(logutilbeta.FromStruct(instance)).
 				Debugf("cached instance was removed")
 			changed = true
 			continue

--- a/pkg/integration/aws/ec2/util.go
+++ b/pkg/integration/aws/ec2/util.go
@@ -3,8 +3,6 @@ package ec2
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/mitchellh/mapstructure"
-	"github.com/sirupsen/logrus"
 )
 
 func ec2tag(instance *ec2.Instance, key string) string {
@@ -15,22 +13,4 @@ func ec2tag(instance *ec2.Instance, key string) string {
 	}
 
 	return ""
-}
-
-func logFieldsFromStruct(s interface{}) logrus.Fields {
-	fields := logrus.Fields{}
-	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		TagName: "logfield",
-		Result:  &fields,
-	})
-	if err != nil {
-		return logrus.Fields{"logfield-error": err}
-	}
-
-	err = dec.Decode(s)
-	if err != nil {
-		return logrus.Fields{"logfield-error": err}
-	}
-
-	return fields
 }

--- a/pkg/integration/aws/spot/spot.go
+++ b/pkg/integration/aws/spot/spot.go
@@ -1,0 +1,234 @@
+// Package spot provides an interface to Spot requests, that are polled from the
+// API. It manages a local cache, which is updated periodically.
+package spot
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/pkg/errors"
+
+	"github.com/rebuy-de/node-drainer/v2/pkg/logutilbeta"
+	"github.com/rebuy-de/node-drainer/v2/pkg/syncutil"
+	"github.com/rebuy-de/rebuy-go-sdk/v2/pkg/logutil"
+)
+
+// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-bid-status.html
+const (
+	StateActive    = "active"
+	StateCancelled = "cancelled"
+	StateFailed    = "failed"
+	StateClosed    = "closed"
+)
+
+const (
+	InstanceStateRunning      = "running"
+	InstanceStateTerminated   = "terminated"
+	InstanceStateShuttingDown = "shutting-down"
+)
+
+// Instance is the instance-related data that is retrieved via API.
+type Instance struct {
+	InstanceID       string    `logfield:"instance-id"`
+	RequestID        string    `logfield:"spot-request-id"`
+	CreateTime       time.Time `logfield:"spot-create-time"`
+	State            string    `logfield:"spot-state"`
+	StatusCode       string    `logfield:"spot-status-code"`
+	StatusUpdateTime time.Time `logfield:"spot-status-update-time"`
+}
+
+// Changed returns true, if relevant fields of the instance changed.
+func (i Instance) Changed(old Instance) bool {
+	return i.State != old.State ||
+		i.StatusCode != old.StatusCode
+}
+
+// Client is an interface to Spot request data.
+type Client interface {
+	// Run executes the EC2 API poller. It will update the instance cache
+	// periodically.
+	Run(context.Context) error
+
+	// List returns all Spot requests that are currently in the cache. Those
+	// instance cache will be updated in the background.
+	List() []Instance
+
+	// SignalEmitter gets triggered every time the cache changes. See syncutil
+	// package for more information.
+	SignalEmitter() *syncutil.SignalEmitter
+
+	// Healthy indicates whether the background job is running correctly.
+	Healthy() bool
+}
+
+type store struct {
+	api     *ec2.EC2
+	refresh time.Duration
+	cache   map[string]Instance
+	emitter *syncutil.SignalEmitter
+
+	failureCount int
+}
+
+// New creates a new client for the EC2 API. It needs to be started with Run so
+// it actually reads messages. See Client interface for more information.
+func New(sess *session.Session, refresh time.Duration) Client {
+	return &store{
+		api:     ec2.New(sess),
+		refresh: refresh,
+		emitter: new(syncutil.SignalEmitter),
+	}
+}
+
+func (s *store) Healthy() bool {
+	return s.failureCount == 0
+}
+
+func (s *store) SignalEmitter() *syncutil.SignalEmitter {
+	return s.emitter
+}
+
+func (s *store) List() []Instance {
+	result := []Instance{}
+
+	for _, instance := range s.cache {
+		result = append(result, instance)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		// Sorting by something other than LaunchTime is required, because the
+		// time has only second precision and it is quite likely that some
+		// instances are started at the same time. And since the list is based
+		// on a map, the order would be flaky.
+		return result[i].InstanceID < result[j].InstanceID
+	})
+
+	sort.SliceStable(result, func(i, j int) bool {
+		return result[i].CreateTime.Before(result[j].CreateTime)
+	})
+
+	return result
+}
+
+func (s *store) Run(ctx context.Context) error {
+	for ctx.Err() == nil {
+		err := s.runOnce(ctx)
+		if err != nil {
+			logutil.Get(ctx).
+				WithError(errors.WithStack(err)).
+				Errorf("main loop run failed %d times in a row", s.failureCount)
+			s.failureCount++
+		} else {
+			s.failureCount = 0
+		}
+
+		time.Sleep(s.refresh)
+	}
+
+	return nil
+}
+
+func (s *store) runOnce(ctx context.Context) error {
+	ctx = logutil.Start(ctx, "update")
+
+	instances, err := s.fetchInstances(ctx)
+	if err != nil {
+		return errors.Wrap(err, "fetching instances failed")
+	}
+
+	changed := false
+
+	// check whether a new instance was added or an existing was changed
+	for _, instance := range instances {
+		old, ok := s.cache[instance.InstanceID]
+		if !ok {
+			logutil.Get(ctx).
+				WithFields(logutilbeta.FromStruct(instance)).
+				Debugf("add new spot instance to cache")
+			changed = true
+			continue
+		}
+
+		if instance.Changed(old) {
+			logutil.Get(ctx).
+				WithFields(logutilbeta.FromStruct(instance)).
+				Debugf("cached spot instance changed")
+			changed = true
+			continue
+		}
+	}
+
+	// check whether an instance was removed
+	for _, instance := range s.cache {
+		_, ok := instances[instance.InstanceID]
+		if !ok {
+			logutil.Get(ctx).
+				WithFields(logutilbeta.FromStruct(instance)).
+				Debugf("cached spot instance was removed")
+			changed = true
+			continue
+		}
+	}
+
+	// Replacing the whole map has the advantage that we do not need locking.
+	s.cache = instances
+
+	// Emitting a signal AFTER refreshing the cache, if anything changed.
+	if changed {
+		s.emitter.Emit()
+	}
+
+	return nil
+}
+
+func (s *store) fetchInstances(ctx context.Context) (map[string]Instance, error) {
+	params := &ec2.DescribeSpotInstanceRequestsInput{}
+	instances := map[string]Instance{}
+
+	for {
+		resp, err := s.api.DescribeSpotInstanceRequests(params)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		for _, dto := range resp.SpotInstanceRequests {
+			id := aws.StringValue(dto.InstanceId)
+
+			if id == "" {
+				// No idea how this could happend. If it happens anyways,
+				// we at least skip the item and log it, so the alerting
+				// gets triggered if it happens more often.
+				logutil.Get(ctx).WithField("spot-instance-dto", dto).Error("got instance with empty spot instance ID")
+				continue
+			}
+
+			instance := Instance{
+				InstanceID: id,
+				RequestID:  aws.StringValue(dto.SpotInstanceRequestId),
+				CreateTime: aws.TimeValue(dto.CreateTime),
+				State:      aws.StringValue(dto.State),
+			}
+
+			if dto.Status != nil {
+				instance.StatusCode = aws.StringValue(dto.Status.Code)
+				instance.StatusUpdateTime = aws.TimeValue(dto.Status.UpdateTime)
+			}
+
+			instances[id] = instance
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+
+		params = &ec2.DescribeSpotInstanceRequestsInput{
+			NextToken: resp.NextToken,
+		}
+	}
+
+	return instances, nil
+}

--- a/pkg/integration/aws/types.go
+++ b/pkg/integration/aws/types.go
@@ -5,14 +5,16 @@ import (
 
 	"github.com/rebuy-de/node-drainer/v2/pkg/integration/aws/asg"
 	"github.com/rebuy-de/node-drainer/v2/pkg/integration/aws/ec2"
+	"github.com/rebuy-de/node-drainer/v2/pkg/integration/aws/spot"
 )
 
 // Instance is the combined data from different sources.
 type Instance struct {
 	InstanceID string `logfield:"instance-id"`
 
-	ASG asg.Instance `logfield:",squash"`
-	EC2 ec2.Instance `logfield:",squash"`
+	ASG  asg.Instance  `logfield:",squash"`
+	EC2  ec2.Instance  `logfield:",squash"`
+	Spot spot.Instance `logfield:",squash"`
 }
 
 // Instances is a collection of Instance types with some additional functions.

--- a/pkg/logutilbeta/struct.go
+++ b/pkg/logutilbeta/struct.go
@@ -1,0 +1,25 @@
+// Should get merged into sdk, soon.
+package logutilbeta
+
+import (
+	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+)
+
+func FromStruct(s interface{}) logrus.Fields {
+	fields := logrus.Fields{}
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "logfield",
+		Result:  &fields,
+	})
+	if err != nil {
+		return logrus.Fields{"logfield-error": err}
+	}
+
+	err = dec.Decode(s)
+	if err != nil {
+		return logrus.Fields{"logfield-error": err}
+	}
+
+	return fields
+}


### PR DESCRIPTION
> https://jira.rebuy.de/browse/CLOUD-2364

This data can later be used for prioritizing terminating spot instances over ASG ones. The advantage of the CloudWatch notifications is a increased visibility of Spot instance states and less dead code that only gets called once a year, when a Spot instance gets terminated.

![image](https://user-images.githubusercontent.com/1698599/84269920-31297c80-ab2a-11ea-90b0-5b3dcd9f57bd.png)


Also:
* Preparing `FromStruct` for the SDK.
* Unify logging a few fields.

Basically a copy of the `ec2` package with a few adjustments. I thought about abstracting common stuff away, but I think this would raise the code complexity a lot. Especially with the given AWS SDK.

```diff
--- ec2/ec2.go	2020-06-10 14:45:54.930141315 +0200
+++ spot/spot.go	2020-06-10 14:44:44.333461855 +0200
@@ -1,6 +1,6 @@
-// Package ec2 provides an interface to EC2 instances, that are polled from the
+// Package spot provides an interface to Spot requests, that are polled from the
 // API. It manages a local cache, which is updated periodically.
-package ec2
+package spot
 
 import (
 	"context"
@@ -17,6 +17,14 @@
 	"github.com/rebuy-de/rebuy-go-sdk/v2/pkg/logutil"
 )
 
+// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-bid-status.html
+const (
+	StateActive    = "active"
+	StateCancelled = "cancelled"
+	StateFailed    = "failed"
+	StateClosed    = "closed"
+)
+
 const (
 	InstanceStateRunning      = "running"
 	InstanceStateTerminated   = "terminated"
@@ -25,29 +33,27 @@
 
 // Instance is the instance-related data that is retrieved via API.
 type Instance struct {
-	InstanceID        string     `logfield:"instance-id"`
-	InstanceName      string     `logfield:"instance-name"`
-	HostName          string     `logfield:"node-name"`
-	InstanceType      string     `logfield:"instance-type"`
-	AvailabilityZone  string     `logfield:"availability-zone"`
-	InstanceLifecycle string     `logfield:"ec2-instance-lifecycle"`
-	State             string     `logfield:"ec2-instance-state"`
-	LaunchTime        time.Time  `logfield:"ec2-launch-time"`
-	TerminationTime   *time.Time `logfield:"ec2-termination-time,omitempty"`
+	InstanceID       string    `logfield:"instance-id"`
+	RequestID        string    `logfield:"spot-request-id"`
+	CreateTime       time.Time `logfield:"spot-create-time"`
+	State            string    `logfield:"spot-state"`
+	StatusCode       string    `logfield:"spot-status-code"`
+	StatusUpdateTime time.Time `logfield:"spot-status-update-time"`
 }
 
 // Changed returns true, if relevant fields of the instance changed.
 func (i Instance) Changed(old Instance) bool {
-	return i.State != old.State
+	return i.State != old.State ||
+		i.StatusCode != old.StatusCode
 }
 
-// Client is an interface to EC2 data.
+// Client is an interface to Spot request data.
 type Client interface {
 	// Run executes the EC2 API poller. It will update the instance cache
 	// periodically.
 	Run(context.Context) error
 
-	// List returns all EC2 Instances that are currently in the cache. Those
+	// List returns all Spot requests that are currently in the cache. Those
 	// instance cache will be updated in the background.
 	List() []Instance
 
@@ -102,7 +108,7 @@
 	})
 
 	sort.SliceStable(result, func(i, j int) bool {
-		return result[i].LaunchTime.Before(result[j].LaunchTime)
+		return result[i].CreateTime.Before(result[j].CreateTime)
 	})
 
 	return result
@@ -142,7 +148,7 @@
 		if !ok {
 			logutil.Get(ctx).
 				WithFields(logutilbeta.FromStruct(instance)).
-				Debugf("add new instance to cache")
+				Debugf("add new spot instance to cache")
 			changed = true
 			continue
 		}
@@ -150,7 +156,7 @@
 		if instance.Changed(old) {
 			logutil.Get(ctx).
 				WithFields(logutilbeta.FromStruct(instance)).
-				Debugf("cached instance changed")
+				Debugf("cached spot instance changed")
 			changed = true
 			continue
 		}
@@ -162,7 +168,7 @@
 		if !ok {
 			logutil.Get(ctx).
 				WithFields(logutilbeta.FromStruct(instance)).
-				Debugf("cached instance was removed")
+				Debugf("cached spot instance was removed")
 			changed = true
 			continue
 		}
@@ -180,65 +186,46 @@
 }
 
 func (s *store) fetchInstances(ctx context.Context) (map[string]Instance, error) {
-	params := &ec2.DescribeInstancesInput{}
+	params := &ec2.DescribeSpotInstanceRequestsInput{}
 	instances := map[string]Instance{}
 
 	for {
-		resp, err := s.api.DescribeInstances(params)
+		resp, err := s.api.DescribeSpotInstanceRequests(params)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
 
-		for _, reservation := range resp.Reservations {
-			for _, dto := range reservation.Instances {
-				id := aws.StringValue(dto.InstanceId)
-
-				if id == "" {
-					// No idea how this could happend. If it happens anyways,
-					// we at least skip the item and log it, so the alerting
-					// gets triggered if it happens more often.
-					logutil.Get(ctx).WithField("instance-dto", dto).Error("got instance with empty instance ID")
-					continue
-				}
-
-				instance := Instance{
-					InstanceID:        id,
-					HostName:          aws.StringValue(dto.PrivateDnsName),
-					State:             aws.StringValue(dto.State.Name),
-					InstanceType:      aws.StringValue(dto.InstanceType),
-					InstanceName:      ec2tag(dto, "Name"),
-					AvailabilityZone:  aws.StringValue(dto.Placement.AvailabilityZone),
-					InstanceLifecycle: aws.StringValue(dto.InstanceLifecycle),
-					LaunchTime:        aws.TimeValue(dto.LaunchTime),
-				}
-
-				if instance.State == InstanceStateTerminated || instance.State == InstanceStateShuttingDown {
-					// Parsing the termination date from the
-					// StateTransitionReason is not very reliable, since it is
-					// not standarized and we do tolarate other reasons. This
-					// is fine, since we use it only for displaying purposes.
-					// If we need a reliable value, we would need to get it
-					// from CloudTrail.
-					terminationTime, err := time.Parse("User initiated (2006-01-02 15:04:05 MST)", aws.StringValue(dto.StateTransitionReason))
-					if err != nil {
-						logutil.Get(ctx).
-							WithField("state-transition-reason", dto.StateTransitionReason).
-							WithError(errors.WithStack(err)).
-							Warn("failed to parse state transition reason")
-					} else {
-						instance.TerminationTime = &terminationTime
-					}
-				}
+		for _, dto := range resp.SpotInstanceRequests {
+			id := aws.StringValue(dto.InstanceId)
+
+			if id == "" {
+				// No idea how this could happend. If it happens anyways,
+				// we at least skip the item and log it, so the alerting
+				// gets triggered if it happens more often.
+				logutil.Get(ctx).WithField("spot-instance-dto", dto).Error("got instance with empty spot instance ID")
+				continue
+			}
+
+			instance := Instance{
+				InstanceID: id,
+				RequestID:  aws.StringValue(dto.SpotInstanceRequestId),
+				CreateTime: aws.TimeValue(dto.CreateTime),
+				State:      aws.StringValue(dto.State),
+			}
 
-				instances[id] = instance
+			if dto.Status != nil {
+				instance.StatusCode = aws.StringValue(dto.Status.Code)
+				instance.StatusUpdateTime = aws.TimeValue(dto.Status.UpdateTime)
 			}
+
+			instances[id] = instance
 		}
 
 		if resp.NextToken == nil {
 			break
 		}
 
-		params = &ec2.DescribeInstancesInput{
+		params = &ec2.DescribeSpotInstanceRequestsInput{
 			NextToken: resp.NextToken,
 		}
 	}

```