### PR TITLE
CLOUD-2379 improve WantsShutdown flag

### DIFF
--- a/cmd/mainloop.go
+++ b/cmd/mainloop.go
@@ -92,7 +92,7 @@ func (l *MainLoop) runOnce(ctx context.Context) error {
 	InstMainLoopStarted(ctx, instances)
 
 	// Mark all instances as complete immediately.
-	for _, instance := range instances.Select(collectors.WantsShutdown) {
+	for _, instance := range instances.Select(collectors.WantsShutdown).Select(collectors.PendingLifecycleCompletion) {
 		InstMainLoopCompletingInstance(ctx, instance)
 
 		err := l.collectors.ASG.Complete(ctx, instance.InstanceID)

--- a/pkg/collectors/instance_select.go
+++ b/pkg/collectors/instance_select.go
@@ -8,6 +8,8 @@ func HasEC2Data(i *Instance) bool { return i.HasEC2Data() }
 
 func WantsShutdown(i *Instance) bool { return i.WantsShutdown() }
 
+func PendingLifecycleCompletion(i *Instance) bool { return i.PendingLifecycleCompletion() }
+
 func HasLifecycleMessage(i *Instance) bool { return i.HasLifecycleMessage() }
 
 func HasEC2State(states ...string) Selector {

--- a/pkg/collectors/pods_sort_test.go
+++ b/pkg/collectors/pods_sort_test.go
@@ -9,22 +9,20 @@ import (
 )
 
 func TestSortPodByNeedsEviction(t *testing.T) {
-	podsWithEvictionNeeded := collectors.Pod{
+	podsWithEvictionNotNeeded := collectors.Pod{
 		Instance: collectors.Instance{
 			InstanceID: "xxx",
 			EC2: ec2.Instance{
 				InstanceID: "xxx",
 				State:      "running",
 			},
-			ASG: asg.Instance{
-				ID:        "xxx",
-				Completed: false,
-			},
 		},
 	}
 
-	podsWithEvictionNotNeeded := podsWithEvictionNeeded
-	podsWithEvictionNotNeeded.Instance.ASG.Completed = true
+	podsWithEvictionNeeded := podsWithEvictionNotNeeded
+	podsWithEvictionNeeded.Instance.ASG = asg.Instance{
+		ID: "xxx",
+	}
 
 	if !podsWithEvictionNeeded.WantsShutdown() {
 		t.Fatal("sanity check failed. pods should want shutdown")


### PR DESCRIPTION
> https://jira.rebuy.de/browse/CLOUD-2379

**Before This Change**: When a new message arrives via SQS, the instance lifecycle gets marked as completed immediately. Therefore the `WantsShutdown` marker is only active for a short period of time.

**After This Change**: An instance is marked a `WantsShutdown` untile it is actually terminated. This improves the visibility in the UI:

![Screenshot 2020-07-02 15:06:34](https://user-images.githubusercontent.com/1698599/86362662-e953cc00-bc75-11ea-9c37-8d2c589ad36d.png)
![Screenshot 2020-07-02 15:06:45](https://user-images.githubusercontent.com/1698599/86362663-ea84f900-bc75-11ea-9e99-bb9bc69baf91.png)