### PR TITLE
improve needseviction marker

### DIFF
--- a/cmd/templates/status.html
+++ b/cmd/templates/status.html
@@ -144,10 +144,10 @@
                     {{ end }}
                 </td>
                 <td>
-                    {{ if .WantsShutdown }}
-                        <span class="badge badge-pill badge-warning">WantsShutdown</span>
-                    {{ end }}
                     {{ template "pretty_node_taints" .Node.Taints }}
+                    {{ if .WantsShutdown }}
+                        <span class="badge badge-warning">WantsShutdown</span>
+                    {{ end }}
                 </td>
               </tr>
             {{ end }}

--- a/pkg/collectors/pods.go
+++ b/pkg/collectors/pods.go
@@ -16,6 +16,10 @@ func (p *Pod) NeedsEviction() bool {
 		return false
 	}
 
+	if p.Pod.ImmuneToEviction() {
+		return false
+	}
+
 	return p.Instance.WantsShutdown()
 }
 


### PR DESCRIPTION
Improve needseviction marker, since having `Pod Needs Eviction` and `Pod Immune To Eviction` on the same pod does not make much sense:

![Screenshot 2020-07-02 15:33:31](https://user-images.githubusercontent.com/1698599/86365294-9c71f480-bc79-11ea-9e54-6f6d39803d89.png)
