### PR TITLE
CLOUD-2387 improve sorting

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -102,15 +102,11 @@ func (s *Server) renderStatus(w http.ResponseWriter, r *http.Request, lists coll
 
 	instances, pods := collectors.Combine(data.Lists)
 
-	data.CombinedInstances = instances.
-		Sort(collectors.ByInstanceID).
-		Sort(collectors.ByLaunchTime).
-		Sort(collectors.ByEC2State).
-		SortReverse(collectors.ByTriggeredAt).
-		Select(collectors.HasEC2Data)
+	SortInstances(instances)
+	SortPods(pods)
 
-	data.CombinedPods = pods.
-		Sort(collectors.PodsByNeedsEviction)
+	data.CombinedInstances = instances.Select(collectors.HasEC2Data)
+	data.CombinedPods = pods
 
 	s.respondTemplate(w, r, "status.html", data)
 }

--- a/cmd/sorters.go
+++ b/cmd/sorters.go
@@ -12,5 +12,6 @@ func SortInstances(instances collectors.Instances) {
 
 func SortPods(pods collectors.Pods) {
 	pods.
-		Sort(collectors.PodsByNeedsEviction)
+		Sort(collectors.PodsByNeedsEviction).
+		Sort(collectors.PodsByImmuneToEviction)
 }

--- a/cmd/sorters.go
+++ b/cmd/sorters.go
@@ -9,3 +9,8 @@ func SortInstances(instances collectors.Instances) {
 		Sort(collectors.ByEC2State).
 		SortReverse(collectors.ByTriggeredAt)
 }
+
+func SortPods(pods collectors.Pods) {
+	pods.
+		Sort(collectors.PodsByNeedsEviction)
+}

--- a/cmd/test-fixtures/status-golden.html
+++ b/cmd/test-fixtures/status-golden.html
@@ -106,6 +106,230 @@
               <tr>
                 <td>i-36d9ff45000000003</td>
                 <td>ip-10-119-176-3.eu-west-1.compute.internal</td>
+                <td>database-0</td>
+                <td>
+                  
+                    <span class="badge badge-success" title="StatefulSet is healthy with 3 pods">StatefulSetOK</span>
+                  
+                </td>
+                <td>
+                  
+                  
+                  
+                </td>
+              </tr>
+            
+              <tr>
+                <td>i-10cd9672000000002</td>
+                <td>ip-10-55-122-2.eu-west-1.compute.internal</td>
+                <td>database-1</td>
+                <td>
+                  
+                    <span class="badge badge-success" title="StatefulSet is healthy with 3 pods">StatefulSetOK</span>
+                  
+                </td>
+                <td>
+                  
+                  
+                  
+                </td>
+              </tr>
+            
+              <tr>
+                <td>i-9acb0442000000001</td>
+                <td>ip-10-9-244-1.eu-west-1.compute.internal</td>
+                <td>database-2</td>
+                <td>
+                  
+                    <span class="badge badge-success" title="StatefulSet is healthy with 3 pods">StatefulSetOK</span>
+                  
+                </td>
+                <td>
+                  
+                  
+                  
+                </td>
+              </tr>
+            
+              <tr>
+                <td>i-36d9ff45000000003</td>
+                <td>ip-10-119-176-3.eu-west-1.compute.internal</td>
+                <td>frontend-40f4c8980f-0691e</td>
+                <td>
+                  
+                    <span class="badge badge-danger" title="Deployment has only 2 of 3 available pods">DeploymentUnready</span>
+                  
+                </td>
+                <td>
+                  
+                  
+                  
+                </td>
+              </tr>
+            
+              <tr>
+                <td>i-9acb0442000000001</td>
+                <td>ip-10-9-244-1.eu-west-1.compute.internal</td>
+                <td>frontend-40f4c8980f-2d942</td>
+                <td>
+                  
+                    <span class="badge badge-danger" title="Deployment has only 2 of 3 available pods">DeploymentUnready</span>
+                  
+                </td>
+                <td>
+                  
+                  
+                  
+                </td>
+              </tr>
+            
+              <tr>
+                <td>i-10cd9672000000002</td>
+                <td>ip-10-55-122-2.eu-west-1.compute.internal</td>
+                <td>frontend-40f4c8980f-6d783</td>
+                <td>
+                  
+                    <span class="badge badge-danger" title="Deployment has only 2 of 3 available pods">DeploymentUnready</span>
+                  
+                </td>
+                <td>
+                  
+                  
+                  
+                </td>
+              </tr>
+            
+              <tr>
+                <td>i-c0a8a05f000000005</td>
+                <td>ip-10-161-105-5.eu-west-1.compute.internal</td>
+                <td>backend-b654304ce9-55552</td>
+                <td>
+                  
+                    <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
+                  
+                </td>
+                <td>
+                  
+                  
+                  
+                </td>
+              </tr>
+            
+              <tr>
+                <td>i-10cd9672000000002</td>
+                <td>ip-10-55-122-2.eu-west-1.compute.internal</td>
+                <td>backend-b654304ce9-711ec</td>
+                <td>
+                  
+                    <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
+                  
+                </td>
+                <td>
+                  
+                  
+                  
+                </td>
+              </tr>
+            
+              <tr>
+                <td>i-9acb0442000000001</td>
+                <td>ip-10-9-244-1.eu-west-1.compute.internal</td>
+                <td>backend-b654304ce9-74cf6</td>
+                <td>
+                  
+                    <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
+                  
+                </td>
+                <td>
+                  
+                  
+                  
+                </td>
+              </tr>
+            
+              <tr>
+                <td>i-10cd9672000000002</td>
+                <td>ip-10-55-122-2.eu-west-1.compute.internal</td>
+                <td>backend-b654304ce9-992df</td>
+                <td>
+                  
+                    <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
+                  
+                </td>
+                <td>
+                  
+                  
+                  
+                </td>
+              </tr>
+            
+              <tr>
+                <td>i-36d9ff45000000003</td>
+                <td>ip-10-119-176-3.eu-west-1.compute.internal</td>
+                <td>backend-b654304ce9-a2125</td>
+                <td>
+                  
+                    <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
+                  
+                </td>
+                <td>
+                  
+                  
+                  
+                </td>
+              </tr>
+            
+              <tr>
+                <td>i-9acb0442000000001</td>
+                <td>ip-10-9-244-1.eu-west-1.compute.internal</td>
+                <td>backend-b654304ce9-d5e12</td>
+                <td>
+                  
+                    <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
+                  
+                </td>
+                <td>
+                  
+                  
+                  
+                </td>
+              </tr>
+            
+              <tr>
+                <td>i-37f317c5000000004</td>
+                <td>ip-10-100-133-4.eu-west-1.compute.internal</td>
+                <td>backend-b654304ce9-8fc6f</td>
+                <td>
+                  
+                    <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
+                  
+                </td>
+                <td>
+                  
+                  
+                  
+                </td>
+              </tr>
+            
+              <tr>
+                <td>i-9b74f61f000000006</td>
+                <td>ip-10-93-23-6.eu-west-1.compute.internal</td>
+                <td>backend-b654304ce9-83111</td>
+                <td>
+                  
+                    <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
+                  
+                </td>
+                <td>
+                  
+                  
+                  
+                </td>
+              </tr>
+            
+              <tr>
+                <td>i-36d9ff45000000003</td>
+                <td>ip-10-119-176-3.eu-west-1.compute.internal</td>
                 <td>kube-proxy-ip-10-119-176-3.eu-west-1.compute.internal</td>
                 <td>
                   
@@ -395,230 +619,6 @@
                   
                   
                     <span class="badge badge-primary">Pod Immune To Eviction</span>
-                  
-                </td>
-              </tr>
-            
-              <tr>
-                <td>i-36d9ff45000000003</td>
-                <td>ip-10-119-176-3.eu-west-1.compute.internal</td>
-                <td>database-0</td>
-                <td>
-                  
-                    <span class="badge badge-success" title="StatefulSet is healthy with 3 pods">StatefulSetOK</span>
-                  
-                </td>
-                <td>
-                  
-                  
-                  
-                </td>
-              </tr>
-            
-              <tr>
-                <td>i-10cd9672000000002</td>
-                <td>ip-10-55-122-2.eu-west-1.compute.internal</td>
-                <td>database-1</td>
-                <td>
-                  
-                    <span class="badge badge-success" title="StatefulSet is healthy with 3 pods">StatefulSetOK</span>
-                  
-                </td>
-                <td>
-                  
-                  
-                  
-                </td>
-              </tr>
-            
-              <tr>
-                <td>i-9acb0442000000001</td>
-                <td>ip-10-9-244-1.eu-west-1.compute.internal</td>
-                <td>database-2</td>
-                <td>
-                  
-                    <span class="badge badge-success" title="StatefulSet is healthy with 3 pods">StatefulSetOK</span>
-                  
-                </td>
-                <td>
-                  
-                  
-                  
-                </td>
-              </tr>
-            
-              <tr>
-                <td>i-36d9ff45000000003</td>
-                <td>ip-10-119-176-3.eu-west-1.compute.internal</td>
-                <td>frontend-40f4c8980f-0691e</td>
-                <td>
-                  
-                    <span class="badge badge-danger" title="Deployment has only 2 of 3 available pods">DeploymentUnready</span>
-                  
-                </td>
-                <td>
-                  
-                  
-                  
-                </td>
-              </tr>
-            
-              <tr>
-                <td>i-9acb0442000000001</td>
-                <td>ip-10-9-244-1.eu-west-1.compute.internal</td>
-                <td>frontend-40f4c8980f-2d942</td>
-                <td>
-                  
-                    <span class="badge badge-danger" title="Deployment has only 2 of 3 available pods">DeploymentUnready</span>
-                  
-                </td>
-                <td>
-                  
-                  
-                  
-                </td>
-              </tr>
-            
-              <tr>
-                <td>i-10cd9672000000002</td>
-                <td>ip-10-55-122-2.eu-west-1.compute.internal</td>
-                <td>frontend-40f4c8980f-6d783</td>
-                <td>
-                  
-                    <span class="badge badge-danger" title="Deployment has only 2 of 3 available pods">DeploymentUnready</span>
-                  
-                </td>
-                <td>
-                  
-                  
-                  
-                </td>
-              </tr>
-            
-              <tr>
-                <td>i-c0a8a05f000000005</td>
-                <td>ip-10-161-105-5.eu-west-1.compute.internal</td>
-                <td>backend-b654304ce9-55552</td>
-                <td>
-                  
-                    <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
-                  
-                </td>
-                <td>
-                  
-                  
-                  
-                </td>
-              </tr>
-            
-              <tr>
-                <td>i-10cd9672000000002</td>
-                <td>ip-10-55-122-2.eu-west-1.compute.internal</td>
-                <td>backend-b654304ce9-711ec</td>
-                <td>
-                  
-                    <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
-                  
-                </td>
-                <td>
-                  
-                  
-                  
-                </td>
-              </tr>
-            
-              <tr>
-                <td>i-9acb0442000000001</td>
-                <td>ip-10-9-244-1.eu-west-1.compute.internal</td>
-                <td>backend-b654304ce9-74cf6</td>
-                <td>
-                  
-                    <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
-                  
-                </td>
-                <td>
-                  
-                  
-                  
-                </td>
-              </tr>
-            
-              <tr>
-                <td>i-10cd9672000000002</td>
-                <td>ip-10-55-122-2.eu-west-1.compute.internal</td>
-                <td>backend-b654304ce9-992df</td>
-                <td>
-                  
-                    <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
-                  
-                </td>
-                <td>
-                  
-                  
-                  
-                </td>
-              </tr>
-            
-              <tr>
-                <td>i-36d9ff45000000003</td>
-                <td>ip-10-119-176-3.eu-west-1.compute.internal</td>
-                <td>backend-b654304ce9-a2125</td>
-                <td>
-                  
-                    <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
-                  
-                </td>
-                <td>
-                  
-                  
-                  
-                </td>
-              </tr>
-            
-              <tr>
-                <td>i-9acb0442000000001</td>
-                <td>ip-10-9-244-1.eu-west-1.compute.internal</td>
-                <td>backend-b654304ce9-d5e12</td>
-                <td>
-                  
-                    <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
-                  
-                </td>
-                <td>
-                  
-                  
-                  
-                </td>
-              </tr>
-            
-              <tr>
-                <td>i-37f317c5000000004</td>
-                <td>ip-10-100-133-4.eu-west-1.compute.internal</td>
-                <td>backend-b654304ce9-8fc6f</td>
-                <td>
-                  
-                    <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
-                  
-                </td>
-                <td>
-                  
-                  
-                  
-                </td>
-              </tr>
-            
-              <tr>
-                <td>i-9b74f61f000000006</td>
-                <td>ip-10-93-23-6.eu-west-1.compute.internal</td>
-                <td>backend-b654304ce9-83111</td>
-                <td>
-                  
-                    <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
-                  
-                </td>
-                <td>
-                  
-                  
                   
                 </td>
               </tr>

--- a/pkg/collectors/pods_sort.go
+++ b/pkg/collectors/pods_sort.go
@@ -7,3 +7,7 @@ type PodsBy func(p1, p2 *Pod) bool
 func PodsByNeedsEviction(p1, p2 *Pod) bool {
 	return p1.NeedsEviction() && !p2.NeedsEviction()
 }
+
+func PodsByImmuneToEviction(p1, p2 *Pod) bool {
+	return p2.Pod.ImmuneToEviction() && !p1.Pod.ImmuneToEviction()
+}


### PR DESCRIPTION
> https://jira.rebuy.de/browse/CLOUD-2387

* Use same common sorter for pods and instances in mainloop and status page. This way we can be sure the we see the same order in the status page as the mainloop is going to delete their pods.
* Put pods that are immune to eviction to the bottom, because they are not much important.

→ [Preview](https://htmlpreview.github.io/?https://github.com/rebuy-de/node-drainer/blob/8bd6715b476d78fe85bf36092156a03186744a2d/cmd/test-fixtures/status-golden.html)