### PR TITLE
CLOUD-2387 Add filter tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ script:
 - docker run
     --rm -t
     -v $TRAVIS_BUILD_DIR:/node-drainer
-    -e TZ=Europe/Berlin
     -w /node-drainer
     quay.io/rebuy/rebuy-go-sdk:v2.4.0
     buildutil -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM quay.io/rebuy/rebuy-go-sdk:v2.4.0 as builder
+ENV TZ=Europe/Berlin
 
 FROM alpine:latest
 RUN apk add --no-cache ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM quay.io/rebuy/rebuy-go-sdk:v2.4.0 as builder
-ENV TZ=Europe/Berlin
 
 FROM alpine:latest
 RUN apk add --no-cache ca-certificates

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -18,6 +18,12 @@ import (
 	"github.com/rebuy-de/node-drainer/v2/pkg/collectors"
 )
 
+// useUTC is used for showing dates to the user. On tests it should always use
+// UTC, but generally it should use the servers time zone. Using the servers
+// time zone is bad for generating golden files, because then the tests would
+// depend on the developers machine settings.
+var useUTC bool
+
 // Healthier is a simple interface, that can easily be implemented by all
 // critical services. It is used to indicate their health statuses.
 type Healthier interface {
@@ -137,7 +143,14 @@ func (s *Server) respondTemplate(w http.ResponseWriter, r *http.Request, name st
 			}
 
 			format := "Mon, 2 Jan 15:04:05"
-			return t.Local().Format(format), nil
+
+			if useUTC {
+				t = t.UTC()
+			} else {
+				t = t.Local()
+			}
+
+			return t.Format(format), nil
 		},
 	})
 

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/rebuy-de/node-drainer/v2/pkg/collectors/testdata"
 )
 
+func init() {
+	useUTC = true
+}
+
 func TestServerRender(t *testing.T) {
 	lists := testdata.Default()
 	server := new(Server)

--- a/cmd/sorters.go
+++ b/cmd/sorters.go
@@ -15,3 +15,16 @@ func SortPods(pods collectors.Pods) {
 		Sort(collectors.PodsByNeedsEviction).
 		Sort(collectors.PodsByImmuneToEviction)
 }
+
+func SelectInstancesThatNeedLifecycleCompletion(instances collectors.Instances) collectors.Instances {
+	return instances.
+		Select(collectors.HasEC2State("running")).
+		Select(collectors.PendingLifecycleCompletion)
+}
+
+func SelectInstancesThanNeedLifecycleDeletion(instances collectors.Instances) collectors.Instances {
+	return instances.
+		Filter(collectors.HasEC2Data).
+		Filter(collectors.PendingLifecycleCompletion).
+		Select(collectors.HasLifecycleMessage)
+}

--- a/cmd/sorters_test.go
+++ b/cmd/sorters_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rebuy-de/node-drainer/v2/pkg/collectors"
+	"github.com/rebuy-de/node-drainer/v2/pkg/collectors/testdata"
+)
+
+func TestSelectInstancesThatNeedLifecycleCompletion(t *testing.T) {
+	b := testdata.NewBuilder()
+
+	for _, ec2State := range testdata.AllEC2States {
+		for _, asgState := range testdata.AllASGStates {
+			b.AddInstance(1, testdata.InstanceTemplate{
+				ASG:  asgState,
+				EC2:  ec2State,
+				Spot: testdata.SpotRunning,
+				Node: testdata.NodeSchedulable,
+				Name: fmt.Sprintf("%v_%v", ec2State, asgState),
+			})
+		}
+	}
+
+	instances, _ := collectors.Combine(b.Build())
+
+	result := SelectInstancesThatNeedLifecycleCompletion(instances)
+	assert.Len(t, result, 2)
+	names := []string{}
+
+	for _, instance := range result {
+		assert.Equal(t, instance.InstanceID, instance.EC2.InstanceID, "should have EC2 data")
+		assert.Equal(t, instance.InstanceID, instance.ASG.ID, "should have ASG data")
+		assert.Equal(t, instance.EC2.State, "running", "should be in running state")
+		assert.False(t, instance.ASG.Completed, "should not be completed yet")
+
+		names = append(names, instance.EC2.InstanceName)
+	}
+
+	assert.Contains(t, names, "running_only-deleted")
+	assert.Contains(t, names, "running_pending")
+}
+
+func TestSelectInstancesThatNeedLifecycleDeletion(t *testing.T) {
+	b := testdata.NewBuilder()
+
+	for _, ec2State := range testdata.AllEC2States {
+		for _, asgState := range testdata.AllASGStates {
+			b.AddInstance(1, testdata.InstanceTemplate{
+				ASG:  asgState,
+				EC2:  ec2State,
+				Spot: testdata.SpotRunning,
+				Node: testdata.NodeSchedulable,
+				Name: fmt.Sprintf("%v_%v", ec2State, asgState),
+			})
+		}
+	}
+
+	instances, _ := collectors.Combine(b.Build())
+
+	result := SelectInstancesThanNeedLifecycleDeletion(instances)
+	assert.Len(t, result, 1)
+
+	for _, instance := range result {
+		assert.Equal(t, instance.EC2.InstanceID, "", "should not have EC2 data")
+		assert.True(t, instance.ASG.Completed, "should be completed")
+		assert.False(t, instance.ASG.Deleted, "should not be deleted")
+	}
+}

--- a/cmd/test-fixtures/status-golden.html
+++ b/cmd/test-fixtures/status-golden.html
@@ -654,8 +654,8 @@
                         <span class="badge badge-success">Running</span>
                     
                 </td>
-                <td>Sat, 11 Jul 07:19:20</td>
-                <td>Sat, 11 Jul 07:49:20</td>
+                <td>Sat, 11 Jul 05:19:20</td>
+                <td>Sat, 11 Jul 05:49:20</td>
                 <td>N/A</td>
                 <td>
                     
@@ -690,8 +690,8 @@
                         <span class="badge badge-success">Running</span>
                     
                 </td>
-                <td>Fri, 10 Jul 09:45:04</td>
-                <td>Fri, 10 Jul 10:15:04</td>
+                <td>Fri, 10 Jul 07:45:04</td>
+                <td>Fri, 10 Jul 08:15:04</td>
                 <td>N/A</td>
                 <td>
                     
@@ -726,9 +726,9 @@
                         <span class="badge badge-danger">Terminated</span>
                     
                 </td>
-                <td>Thu, 9 Jul 01:25:32</td>
-                <td>Thu, 9 Jul 01:55:32</td>
-                <td>Thu, 9 Jul 02:25:32</td>
+                <td>Wed, 8 Jul 23:25:32</td>
+                <td>Wed, 8 Jul 23:55:32</td>
+                <td>Thu, 9 Jul 00:25:32</td>
                 <td>
                     
                     <span class="badge badge-pill badge-stats badge-dark" title="Total">0</span>
@@ -751,9 +751,9 @@
                         <span class="badge badge-danger">Terminated</span>
                     
                 </td>
-                <td>Tue, 7 Jul 00:14:33</td>
-                <td>Tue, 7 Jul 00:44:33</td>
-                <td>Tue, 7 Jul 01:14:33</td>
+                <td>Mon, 6 Jul 22:14:33</td>
+                <td>Mon, 6 Jul 22:44:33</td>
+                <td>Mon, 6 Jul 23:14:33</td>
                 <td>
                     
                     <span class="badge badge-pill badge-stats badge-dark" title="Total">0</span>
@@ -776,9 +776,9 @@
                         <span class="badge badge-danger">Terminated</span>
                     
                 </td>
-                <td>Mon, 6 Jul 23:38:12</td>
-                <td>Tue, 7 Jul 00:08:12</td>
-                <td>Tue, 7 Jul 00:38:12</td>
+                <td>Mon, 6 Jul 21:38:12</td>
+                <td>Mon, 6 Jul 22:08:12</td>
+                <td>Mon, 6 Jul 22:38:12</td>
                 <td>
                     
                     <span class="badge badge-pill badge-stats badge-dark" title="Total">0</span>
@@ -801,9 +801,9 @@
                         <span class="badge badge-danger">Terminated</span>
                     
                 </td>
-                <td>Sun, 12 Jul 10:51:07</td>
+                <td>Sun, 12 Jul 08:51:07</td>
                 <td>N/A</td>
-                <td>Sun, 12 Jul 11:51:07</td>
+                <td>Sun, 12 Jul 09:51:07</td>
                 <td>
                     
                     <span class="badge badge-pill badge-stats badge-dark" title="Total">0</span>
@@ -826,9 +826,9 @@
                         <span class="badge badge-danger">Terminated</span>
                     
                 </td>
-                <td>Sat, 11 Jul 08:23:37</td>
+                <td>Sat, 11 Jul 06:23:37</td>
                 <td>N/A</td>
-                <td>Sat, 11 Jul 09:23:37</td>
+                <td>Sat, 11 Jul 07:23:37</td>
                 <td>
                     
                     <span class="badge badge-pill badge-stats badge-dark" title="Total">0</span>
@@ -851,9 +851,9 @@
                         <span class="badge badge-danger">Terminated</span>
                     
                 </td>
-                <td>Tue, 7 Jul 19:10:54</td>
+                <td>Tue, 7 Jul 17:10:54</td>
                 <td>N/A</td>
-                <td>Tue, 7 Jul 20:10:54</td>
+                <td>Tue, 7 Jul 18:10:54</td>
                 <td>
                     
                     <span class="badge badge-pill badge-stats badge-dark" title="Total">0</span>
@@ -876,9 +876,9 @@
                         <span class="badge badge-warning">Shutting Down</span>
                     
                 </td>
-                <td>Sun, 12 Jul 06:37:13</td>
+                <td>Sun, 12 Jul 04:37:13</td>
                 <td>N/A</td>
-                <td>Sun, 12 Jul 07:37:13</td>
+                <td>Sun, 12 Jul 05:37:13</td>
                 <td>
                     
                     <span class="badge badge-pill badge-stats badge-dark" title="Total">0</span>
@@ -901,9 +901,9 @@
                         <span class="badge badge-warning">Shutting Down</span>
                     
                 </td>
-                <td>Wed, 8 Jul 15:27:39</td>
+                <td>Wed, 8 Jul 13:27:39</td>
                 <td>N/A</td>
-                <td>Wed, 8 Jul 16:27:39</td>
+                <td>Wed, 8 Jul 14:27:39</td>
                 <td>
                     
                     <span class="badge badge-pill badge-stats badge-dark" title="Total">0</span>
@@ -926,7 +926,7 @@
                         <span class="badge badge-success">Running</span>
                     
                 </td>
-                <td>Mon, 13 Jul 04:09:00</td>
+                <td>Mon, 13 Jul 02:09:00</td>
                 <td>N/A</td>
                 <td>N/A</td>
                 <td>
@@ -958,7 +958,7 @@
                         <span class="badge badge-success">Running</span>
                     
                 </td>
-                <td>Sun, 12 Jul 09:41:29</td>
+                <td>Sun, 12 Jul 07:41:29</td>
                 <td>N/A</td>
                 <td>N/A</td>
                 <td>
@@ -998,7 +998,7 @@
                         <span class="badge badge-success">Running</span>
                     
                 </td>
-                <td>Sat, 11 Jul 20:39:31</td>
+                <td>Sat, 11 Jul 18:39:31</td>
                 <td>N/A</td>
                 <td>N/A</td>
                 <td>
@@ -1032,7 +1032,7 @@
                         <span class="badge badge-success">Running</span>
                     
                 </td>
-                <td>Sat, 11 Jul 02:03:17</td>
+                <td>Sat, 11 Jul 00:03:17</td>
                 <td>N/A</td>
                 <td>N/A</td>
                 <td>
@@ -1070,7 +1070,7 @@
                         <span class="badge badge-success">Running</span>
                     
                 </td>
-                <td>Thu, 9 Jul 15:40:58</td>
+                <td>Thu, 9 Jul 13:40:58</td>
                 <td>N/A</td>
                 <td>N/A</td>
                 <td>
@@ -1102,7 +1102,7 @@
                         <span class="badge badge-success">Running</span>
                     
                 </td>
-                <td>Mon, 6 Jul 20:36:54</td>
+                <td>Mon, 6 Jul 18:36:54</td>
                 <td>N/A</td>
                 <td>N/A</td>
                 <td>
@@ -1136,7 +1136,7 @@
                         <span class="badge badge-info">Pending</span>
                     
                 </td>
-                <td>Mon, 13 Jul 00:32:17</td>
+                <td>Sun, 12 Jul 22:32:17</td>
                 <td>N/A</td>
                 <td>N/A</td>
                 <td>
@@ -1174,196 +1174,196 @@
               <tr>
                 <td>i-36d9ff45000000003</td>
                 <td>sir-add87e4a</td>
-                <td>Sun, 12 Jul 09:41:29</td>
+                <td>Sun, 12 Jul 07:41:29</td>
                 <td>
                     
                         <span class="badge badge-success">Active</span>
                     
                 </td>
                 <td><code>fulfilled</code></td>
-                <td>Sun, 12 Jul 09:41:29</td>
+                <td>Sun, 12 Jul 07:41:29</td>
               </tr>
             
               <tr>
                 <td>i-37f317c5000000004</td>
                 <td>sir-4c0d9a56</td>
-                <td>Sat, 11 Jul 02:03:17</td>
+                <td>Sat, 11 Jul 00:03:17</td>
                 <td>
                     
                         <span class="badge badge-success">Active</span>
                     
                 </td>
                 <td><code>fulfilled</code></td>
-                <td>Sat, 11 Jul 02:03:17</td>
+                <td>Sat, 11 Jul 00:03:17</td>
               </tr>
             
               <tr>
                 <td>i-c0a8a05f000000005</td>
                 <td>sir-288833b6</td>
-                <td>Sat, 11 Jul 20:39:31</td>
+                <td>Sat, 11 Jul 18:39:31</td>
                 <td>
                     
                         <span class="badge badge-success">Active</span>
                     
                 </td>
                 <td><code>fulfilled</code></td>
-                <td>Sat, 11 Jul 20:39:31</td>
+                <td>Sat, 11 Jul 18:39:31</td>
               </tr>
             
               <tr>
                 <td>i-9b74f61f000000006</td>
                 <td>sir-4d309725</td>
-                <td>Mon, 6 Jul 20:36:54</td>
+                <td>Mon, 6 Jul 18:36:54</td>
                 <td>
                     
                         <span class="badge badge-success">Active</span>
                     
                 </td>
                 <td><code>fulfilled</code></td>
-                <td>Mon, 6 Jul 20:36:54</td>
+                <td>Mon, 6 Jul 18:36:54</td>
               </tr>
             
               <tr>
                 <td>i-2c5b2d1a000000007</td>
                 <td>sir-40e807bd</td>
-                <td>Sun, 12 Jul 10:51:07</td>
+                <td>Sun, 12 Jul 08:51:07</td>
                 <td>
                     
                         <span class="badge badge-danger">Closed</span>
                     
                 </td>
                 <td><code>instance-terminated-by-user</code></td>
-                <td>Sun, 12 Jul 10:51:07</td>
+                <td>Sun, 12 Jul 08:51:07</td>
               </tr>
             
               <tr>
                 <td>i-483675c8000000008</td>
                 <td>sir-18f2c92e</td>
-                <td>Tue, 7 Jul 19:10:54</td>
+                <td>Tue, 7 Jul 17:10:54</td>
                 <td>
                     
                         <span class="badge badge-danger">Closed</span>
                     
                 </td>
                 <td><code>instance-terminated-by-user</code></td>
-                <td>Tue, 7 Jul 19:10:54</td>
+                <td>Tue, 7 Jul 17:10:54</td>
               </tr>
             
               <tr>
                 <td>i-fa173951000000009</td>
                 <td>sir-eecf0606</td>
-                <td>Sat, 11 Jul 08:23:37</td>
+                <td>Sat, 11 Jul 06:23:37</td>
                 <td>
                     
                         <span class="badge badge-danger">Closed</span>
                     
                 </td>
                 <td><code>instance-terminated-by-user</code></td>
-                <td>Sat, 11 Jul 08:23:37</td>
+                <td>Sat, 11 Jul 06:23:37</td>
               </tr>
             
               <tr>
                 <td>i-bde9d03d000000010</td>
                 <td>sir-aec26105</td>
-                <td>Tue, 7 Jul 00:14:33</td>
+                <td>Mon, 6 Jul 22:14:33</td>
                 <td>
                     
                         <span class="badge badge-danger">Closed</span>
                     
                 </td>
                 <td><code>instance-terminated-by-user</code></td>
-                <td>Tue, 7 Jul 00:14:33</td>
+                <td>Mon, 6 Jul 22:14:33</td>
               </tr>
             
               <tr>
                 <td>i-fa9b1d3f000000011</td>
                 <td>sir-591382ce</td>
-                <td>Mon, 6 Jul 23:38:12</td>
+                <td>Mon, 6 Jul 21:38:12</td>
                 <td>
                     
                         <span class="badge badge-danger">Closed</span>
                     
                 </td>
                 <td><code>instance-terminated-by-user</code></td>
-                <td>Mon, 6 Jul 23:38:12</td>
+                <td>Mon, 6 Jul 21:38:12</td>
               </tr>
             
               <tr>
                 <td>i-b0dad04c000000012</td>
                 <td>sir-675fa6f2</td>
-                <td>Thu, 9 Jul 01:25:32</td>
+                <td>Wed, 8 Jul 23:25:32</td>
                 <td>
                     
                         <span class="badge badge-danger">Closed</span>
                     
                 </td>
                 <td><code>instance-terminated-by-user</code></td>
-                <td>Thu, 9 Jul 01:25:32</td>
+                <td>Wed, 8 Jul 23:25:32</td>
               </tr>
             
               <tr>
                 <td>i-21725a02000000013</td>
                 <td>sir-15e4ac07</td>
-                <td>Wed, 8 Jul 15:27:39</td>
+                <td>Wed, 8 Jul 13:27:39</td>
                 <td>
                     
                         <span class="badge badge-success">Active</span>
                     
                 </td>
                 <td><code>fulfilled</code></td>
-                <td>Wed, 8 Jul 15:27:39</td>
+                <td>Wed, 8 Jul 13:27:39</td>
               </tr>
             
               <tr>
                 <td>i-ab694965000000014</td>
                 <td>sir-3d24aa0f</td>
-                <td>Sun, 12 Jul 06:37:13</td>
+                <td>Sun, 12 Jul 04:37:13</td>
                 <td>
                     
                         <span class="badge badge-success">Active</span>
                     
                 </td>
                 <td><code>fulfilled</code></td>
-                <td>Sun, 12 Jul 06:37:13</td>
+                <td>Sun, 12 Jul 04:37:13</td>
               </tr>
             
               <tr>
                 <td>i-a0cb0ab0000000015</td>
                 <td>sir-8cd66db7</td>
-                <td>Mon, 13 Jul 00:32:17</td>
+                <td>Sun, 12 Jul 22:32:17</td>
                 <td>
                     
                         <span class="badge badge-success">Active</span>
                     
                 </td>
                 <td><code>fulfilled</code></td>
-                <td>Mon, 13 Jul 00:32:17</td>
+                <td>Sun, 12 Jul 22:32:17</td>
               </tr>
             
               <tr>
                 <td>i-9fa4d3fb000000016</td>
                 <td>sir-7f7448e0</td>
-                <td>Sat, 11 Jul 07:19:20</td>
+                <td>Sat, 11 Jul 05:19:20</td>
                 <td>
                     
                         <span class="badge badge-success">Active</span>
                     
                 </td>
                 <td><code>fulfilled</code></td>
-                <td>Sat, 11 Jul 07:19:20</td>
+                <td>Sat, 11 Jul 05:19:20</td>
               </tr>
             
               <tr>
                 <td>i-9a9e4f14000000017</td>
                 <td>sir-96ff5f86</td>
-                <td>Fri, 10 Jul 09:45:04</td>
+                <td>Fri, 10 Jul 07:45:04</td>
                 <td>
                     
                         <span class="badge badge-success">Active</span>
                     
                 </td>
                 <td><code>fulfilled</code></td>
-                <td>Fri, 10 Jul 09:45:04</td>
+                <td>Fri, 10 Jul 07:45:04</td>
               </tr>
             
           </tbody>
@@ -1386,7 +1386,7 @@
             
               <tr>
                 <td>i-bde9d03d000000010</td>
-                <td>Tue, 7 Jul 00:44:33</td>
+                <td>Mon, 6 Jul 22:44:33</td>
                 <td>
                     
                         <span class="badge badge-success">yes</span>
@@ -1401,7 +1401,7 @@
             
               <tr>
                 <td>i-fa9b1d3f000000011</td>
-                <td>Tue, 7 Jul 00:08:12</td>
+                <td>Mon, 6 Jul 22:08:12</td>
                 <td>
                     
                         <span class="badge badge-success">yes</span>
@@ -1416,7 +1416,7 @@
             
               <tr>
                 <td>i-b0dad04c000000012</td>
-                <td>Thu, 9 Jul 01:55:32</td>
+                <td>Wed, 8 Jul 23:55:32</td>
                 <td>
                     
                         <span class="badge badge-info">no</span>
@@ -1431,7 +1431,7 @@
             
               <tr>
                 <td>i-9fa4d3fb000000016</td>
-                <td>Sat, 11 Jul 07:49:20</td>
+                <td>Sat, 11 Jul 05:49:20</td>
                 <td>
                     
                         <span class="badge badge-info">no</span>
@@ -1446,7 +1446,7 @@
             
               <tr>
                 <td>i-9a9e4f14000000017</td>
-                <td>Fri, 10 Jul 10:15:04</td>
+                <td>Fri, 10 Jul 08:15:04</td>
                 <td>
                     
                         <span class="badge badge-info">no</span>
@@ -1662,7 +1662,7 @@
                         <span class="badge badge-success">Running</span>
                     
                 </td>
-                <td>Thu, 9 Jul 15:40:58</td>
+                <td>Thu, 9 Jul 13:40:58</td>
                 <td>N/A</td>
               </tr>
             
@@ -1678,7 +1678,7 @@
                         <span class="badge badge-success">Running</span>
                     
                 </td>
-                <td>Mon, 13 Jul 04:09:00</td>
+                <td>Mon, 13 Jul 02:09:00</td>
                 <td>N/A</td>
               </tr>
             
@@ -1694,7 +1694,7 @@
                         <span class="badge badge-success">Running</span>
                     
                 </td>
-                <td>Sun, 12 Jul 09:41:29</td>
+                <td>Sun, 12 Jul 07:41:29</td>
                 <td>N/A</td>
               </tr>
             
@@ -1710,7 +1710,7 @@
                         <span class="badge badge-success">Running</span>
                     
                 </td>
-                <td>Sat, 11 Jul 02:03:17</td>
+                <td>Sat, 11 Jul 00:03:17</td>
                 <td>N/A</td>
               </tr>
             
@@ -1726,7 +1726,7 @@
                         <span class="badge badge-success">Running</span>
                     
                 </td>
-                <td>Sat, 11 Jul 20:39:31</td>
+                <td>Sat, 11 Jul 18:39:31</td>
                 <td>N/A</td>
               </tr>
             
@@ -1742,7 +1742,7 @@
                         <span class="badge badge-success">Running</span>
                     
                 </td>
-                <td>Mon, 6 Jul 20:36:54</td>
+                <td>Mon, 6 Jul 18:36:54</td>
                 <td>N/A</td>
               </tr>
             
@@ -1758,8 +1758,8 @@
                         <span class="badge badge-danger">Terminated</span>
                     
                 </td>
-                <td>Sun, 12 Jul 10:51:07</td>
-                <td>Sun, 12 Jul 11:51:07</td>
+                <td>Sun, 12 Jul 08:51:07</td>
+                <td>Sun, 12 Jul 09:51:07</td>
               </tr>
             
               <tr>
@@ -1774,8 +1774,8 @@
                         <span class="badge badge-danger">Terminated</span>
                     
                 </td>
-                <td>Tue, 7 Jul 19:10:54</td>
-                <td>Tue, 7 Jul 20:10:54</td>
+                <td>Tue, 7 Jul 17:10:54</td>
+                <td>Tue, 7 Jul 18:10:54</td>
               </tr>
             
               <tr>
@@ -1790,8 +1790,8 @@
                         <span class="badge badge-danger">Terminated</span>
                     
                 </td>
-                <td>Sat, 11 Jul 08:23:37</td>
-                <td>Sat, 11 Jul 09:23:37</td>
+                <td>Sat, 11 Jul 06:23:37</td>
+                <td>Sat, 11 Jul 07:23:37</td>
               </tr>
             
               <tr>
@@ -1806,8 +1806,8 @@
                         <span class="badge badge-danger">Terminated</span>
                     
                 </td>
-                <td>Tue, 7 Jul 00:14:33</td>
-                <td>Tue, 7 Jul 01:14:33</td>
+                <td>Mon, 6 Jul 22:14:33</td>
+                <td>Mon, 6 Jul 23:14:33</td>
               </tr>
             
               <tr>
@@ -1822,8 +1822,8 @@
                         <span class="badge badge-danger">Terminated</span>
                     
                 </td>
-                <td>Mon, 6 Jul 23:38:12</td>
-                <td>Tue, 7 Jul 00:38:12</td>
+                <td>Mon, 6 Jul 21:38:12</td>
+                <td>Mon, 6 Jul 22:38:12</td>
               </tr>
             
               <tr>
@@ -1838,8 +1838,8 @@
                         <span class="badge badge-danger">Terminated</span>
                     
                 </td>
-                <td>Thu, 9 Jul 01:25:32</td>
-                <td>Thu, 9 Jul 02:25:32</td>
+                <td>Wed, 8 Jul 23:25:32</td>
+                <td>Thu, 9 Jul 00:25:32</td>
               </tr>
             
               <tr>
@@ -1854,8 +1854,8 @@
                         <span class="badge badge-warning">Shutting Down</span>
                     
                 </td>
-                <td>Wed, 8 Jul 15:27:39</td>
-                <td>Wed, 8 Jul 16:27:39</td>
+                <td>Wed, 8 Jul 13:27:39</td>
+                <td>Wed, 8 Jul 14:27:39</td>
               </tr>
             
               <tr>
@@ -1870,8 +1870,8 @@
                         <span class="badge badge-warning">Shutting Down</span>
                     
                 </td>
-                <td>Sun, 12 Jul 06:37:13</td>
-                <td>Sun, 12 Jul 07:37:13</td>
+                <td>Sun, 12 Jul 04:37:13</td>
+                <td>Sun, 12 Jul 05:37:13</td>
               </tr>
             
               <tr>
@@ -1886,7 +1886,7 @@
                         <span class="badge badge-info">Pending</span>
                     
                 </td>
-                <td>Mon, 13 Jul 00:32:17</td>
+                <td>Sun, 12 Jul 22:32:17</td>
                 <td>N/A</td>
               </tr>
             
@@ -1902,7 +1902,7 @@
                         <span class="badge badge-success">Running</span>
                     
                 </td>
-                <td>Sat, 11 Jul 07:19:20</td>
+                <td>Sat, 11 Jul 05:19:20</td>
                 <td>N/A</td>
               </tr>
             
@@ -1918,7 +1918,7 @@
                         <span class="badge badge-success">Running</span>
                     
                 </td>
-                <td>Fri, 10 Jul 09:45:04</td>
+                <td>Fri, 10 Jul 07:45:04</td>
                 <td>N/A</td>
               </tr>
             
@@ -1945,7 +1945,7 @@
                 <td>ip-10-119-176-3.eu-west-1.compute.internal</td>
                 <td>kube-proxy-ip-10-119-176-3.eu-west-1.compute.internal</td>
                 <td>kube-system</td>
-                <td>Thu, 9 Jul 09:28:47</td>
+                <td>Thu, 9 Jul 07:28:47</td>
                 <td>
                   
                     <span class="badge badge-success" title="Node Pods are always allowed">IsNodePod</span>
@@ -1963,7 +1963,7 @@
                 <td>ip-10-55-122-2.eu-west-1.compute.internal</td>
                 <td>kube-proxy-ip-10-55-122-2.eu-west-1.compute.internal</td>
                 <td>kube-system</td>
-                <td>Wed, 8 Jul 05:48:33</td>
+                <td>Wed, 8 Jul 03:48:33</td>
                 <td>
                   
                     <span class="badge badge-success" title="Node Pods are always allowed">IsNodePod</span>
@@ -1981,7 +1981,7 @@
                 <td>ip-10-87-167-17.eu-west-1.compute.internal</td>
                 <td>kube-proxy-ip-10-87-167-17.eu-west-1.compute.internal</td>
                 <td>kube-system</td>
-                <td>Fri, 10 Jul 05:59:38</td>
+                <td>Fri, 10 Jul 03:59:38</td>
                 <td>
                   
                     <span class="badge badge-success" title="Node Pods are always allowed">IsNodePod</span>
@@ -1999,7 +1999,7 @@
                 <td>ip-10-93-23-6.eu-west-1.compute.internal</td>
                 <td>kube-proxy-ip-10-93-23-6.eu-west-1.compute.internal</td>
                 <td>kube-system</td>
-                <td>Thu, 9 Jul 12:51:42</td>
+                <td>Thu, 9 Jul 10:51:42</td>
                 <td>
                   
                     <span class="badge badge-success" title="Node Pods are always allowed">IsNodePod</span>
@@ -2017,7 +2017,7 @@
                 <td>ip-10-100-133-4.eu-west-1.compute.internal</td>
                 <td>kube-proxy-ip-10-100-133-4.eu-west-1.compute.internal</td>
                 <td>kube-system</td>
-                <td>Wed, 8 Jul 15:27:25</td>
+                <td>Wed, 8 Jul 13:27:25</td>
                 <td>
                   
                     <span class="badge badge-success" title="Node Pods are always allowed">IsNodePod</span>
@@ -2035,7 +2035,7 @@
                 <td>ip-10-9-244-1.eu-west-1.compute.internal</td>
                 <td>kube-proxy-ip-10-9-244-1.eu-west-1.compute.internal</td>
                 <td>kube-system</td>
-                <td>Thu, 9 Jul 02:31:31</td>
+                <td>Thu, 9 Jul 00:31:31</td>
                 <td>
                   
                     <span class="badge badge-success" title="Node Pods are always allowed">IsNodePod</span>
@@ -2053,7 +2053,7 @@
                 <td>ip-10-139-70-16.eu-west-1.compute.internal</td>
                 <td>kube-proxy-ip-10-139-70-16.eu-west-1.compute.internal</td>
                 <td>kube-system</td>
-                <td>Wed, 8 Jul 01:01:50</td>
+                <td>Tue, 7 Jul 23:01:50</td>
                 <td>
                   
                     <span class="badge badge-success" title="Node Pods are always allowed">IsNodePod</span>
@@ -2071,7 +2071,7 @@
                 <td>ip-10-161-105-5.eu-west-1.compute.internal</td>
                 <td>kube-proxy-ip-10-161-105-5.eu-west-1.compute.internal</td>
                 <td>kube-system</td>
-                <td>Sat, 11 Jul 19:42:41</td>
+                <td>Sat, 11 Jul 17:42:41</td>
                 <td>
                   
                     <span class="badge badge-success" title="Node Pods are always allowed">IsNodePod</span>
@@ -2089,7 +2089,7 @@
                 <td>ip-10-9-244-1.eu-west-1.compute.internal</td>
                 <td>dns-98e73</td>
                 <td>kube-system</td>
-                <td>Mon, 13 Jul 12:56:45</td>
+                <td>Mon, 13 Jul 10:56:45</td>
                 <td>
                   
                     <span class="badge badge-success" title="DaemonSet Pods are always allowed">IsDaemonSetPod</span>
@@ -2107,7 +2107,7 @@
                 <td>ip-10-55-122-2.eu-west-1.compute.internal</td>
                 <td>dns-0ec63</td>
                 <td>kube-system</td>
-                <td>Wed, 8 Jul 22:26:59</td>
+                <td>Wed, 8 Jul 20:26:59</td>
                 <td>
                   
                     <span class="badge badge-success" title="DaemonSet Pods are always allowed">IsDaemonSetPod</span>
@@ -2125,7 +2125,7 @@
                 <td>ip-10-100-133-4.eu-west-1.compute.internal</td>
                 <td>dns-a287e</td>
                 <td>kube-system</td>
-                <td>Sat, 11 Jul 00:11:52</td>
+                <td>Fri, 10 Jul 22:11:52</td>
                 <td>
                   
                     <span class="badge badge-success" title="DaemonSet Pods are always allowed">IsDaemonSetPod</span>
@@ -2143,7 +2143,7 @@
                 <td>ip-10-87-167-17.eu-west-1.compute.internal</td>
                 <td>dns-4a713</td>
                 <td>kube-system</td>
-                <td>Sun, 12 Jul 01:14:53</td>
+                <td>Sat, 11 Jul 23:14:53</td>
                 <td>
                   
                     <span class="badge badge-success" title="DaemonSet Pods are always allowed">IsDaemonSetPod</span>
@@ -2161,7 +2161,7 @@
                 <td>ip-10-161-105-5.eu-west-1.compute.internal</td>
                 <td>dns-d01aa</td>
                 <td>kube-system</td>
-                <td>Tue, 7 Jul 16:24:02</td>
+                <td>Tue, 7 Jul 14:24:02</td>
                 <td>
                   
                     <span class="badge badge-success" title="DaemonSet Pods are always allowed">IsDaemonSetPod</span>
@@ -2179,7 +2179,7 @@
                 <td>ip-10-119-176-3.eu-west-1.compute.internal</td>
                 <td>dns-af451</td>
                 <td>kube-system</td>
-                <td>Sun, 12 Jul 21:51:09</td>
+                <td>Sun, 12 Jul 19:51:09</td>
                 <td>
                   
                     <span class="badge badge-success" title="DaemonSet Pods are always allowed">IsDaemonSetPod</span>
@@ -2197,7 +2197,7 @@
                 <td>ip-10-93-23-6.eu-west-1.compute.internal</td>
                 <td>dns-a83b4</td>
                 <td>kube-system</td>
-                <td>Fri, 10 Jul 16:58:27</td>
+                <td>Fri, 10 Jul 14:58:27</td>
                 <td>
                   
                     <span class="badge badge-success" title="DaemonSet Pods are always allowed">IsDaemonSetPod</span>
@@ -2215,7 +2215,7 @@
                 <td>ip-10-139-70-16.eu-west-1.compute.internal</td>
                 <td>dns-167ad</td>
                 <td>kube-system</td>
-                <td>Sat, 11 Jul 09:02:00</td>
+                <td>Sat, 11 Jul 07:02:00</td>
                 <td>
                   
                     <span class="badge badge-success" title="DaemonSet Pods are always allowed">IsDaemonSetPod</span>
@@ -2233,7 +2233,7 @@
                 <td>ip-10-119-176-3.eu-west-1.compute.internal</td>
                 <td>database-0</td>
                 <td>default</td>
-                <td>Fri, 10 Jul 00:10:48</td>
+                <td>Thu, 9 Jul 22:10:48</td>
                 <td>
                   
                     <span class="badge badge-success" title="StatefulSet is healthy with 3 pods">StatefulSetOK</span>
@@ -2251,7 +2251,7 @@
                 <td>ip-10-55-122-2.eu-west-1.compute.internal</td>
                 <td>database-1</td>
                 <td>default</td>
-                <td>Wed, 8 Jul 08:26:24</td>
+                <td>Wed, 8 Jul 06:26:24</td>
                 <td>
                   
                     <span class="badge badge-success" title="StatefulSet is healthy with 3 pods">StatefulSetOK</span>
@@ -2269,7 +2269,7 @@
                 <td>ip-10-9-244-1.eu-west-1.compute.internal</td>
                 <td>database-2</td>
                 <td>default</td>
-                <td>Wed, 8 Jul 22:33:06</td>
+                <td>Wed, 8 Jul 20:33:06</td>
                 <td>
                   
                     <span class="badge badge-success" title="StatefulSet is healthy with 3 pods">StatefulSetOK</span>
@@ -2287,7 +2287,7 @@
                 <td>ip-10-119-176-3.eu-west-1.compute.internal</td>
                 <td>frontend-40f4c8980f-0691e</td>
                 <td>default</td>
-                <td>Mon, 6 Jul 19:51:12</td>
+                <td>Mon, 6 Jul 17:51:12</td>
                 <td>
                   
                     <span class="badge badge-danger" title="Deployment has only 2 of 3 available pods">DeploymentUnready</span>
@@ -2305,7 +2305,7 @@
                 <td>ip-10-9-244-1.eu-west-1.compute.internal</td>
                 <td>frontend-40f4c8980f-2d942</td>
                 <td>default</td>
-                <td>Sun, 12 Jul 22:50:10</td>
+                <td>Sun, 12 Jul 20:50:10</td>
                 <td>
                   
                     <span class="badge badge-danger" title="Deployment has only 2 of 3 available pods">DeploymentUnready</span>
@@ -2323,7 +2323,7 @@
                 <td>ip-10-55-122-2.eu-west-1.compute.internal</td>
                 <td>frontend-40f4c8980f-6d783</td>
                 <td>default</td>
-                <td>Sat, 11 Jul 07:02:28</td>
+                <td>Sat, 11 Jul 05:02:28</td>
                 <td>
                   
                     <span class="badge badge-danger" title="Deployment has only 2 of 3 available pods">DeploymentUnready</span>
@@ -2341,7 +2341,7 @@
                 <td>ip-10-161-105-5.eu-west-1.compute.internal</td>
                 <td>backend-b654304ce9-55552</td>
                 <td>default</td>
-                <td>Sat, 11 Jul 10:51:48</td>
+                <td>Sat, 11 Jul 08:51:48</td>
                 <td>
                   
                     <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
@@ -2359,7 +2359,7 @@
                 <td>ip-10-55-122-2.eu-west-1.compute.internal</td>
                 <td>backend-b654304ce9-711ec</td>
                 <td>default</td>
-                <td>Thu, 9 Jul 01:39:21</td>
+                <td>Wed, 8 Jul 23:39:21</td>
                 <td>
                   
                     <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
@@ -2377,7 +2377,7 @@
                 <td>ip-10-9-244-1.eu-west-1.compute.internal</td>
                 <td>backend-b654304ce9-74cf6</td>
                 <td>default</td>
-                <td>Sun, 12 Jul 20:51:04</td>
+                <td>Sun, 12 Jul 18:51:04</td>
                 <td>
                   
                     <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
@@ -2395,7 +2395,7 @@
                 <td>ip-10-55-122-2.eu-west-1.compute.internal</td>
                 <td>backend-b654304ce9-992df</td>
                 <td>default</td>
-                <td>Wed, 8 Jul 04:03:00</td>
+                <td>Wed, 8 Jul 02:03:00</td>
                 <td>
                   
                     <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
@@ -2413,7 +2413,7 @@
                 <td>ip-10-119-176-3.eu-west-1.compute.internal</td>
                 <td>backend-b654304ce9-a2125</td>
                 <td>default</td>
-                <td>Tue, 7 Jul 06:17:32</td>
+                <td>Tue, 7 Jul 04:17:32</td>
                 <td>
                   
                     <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
@@ -2431,7 +2431,7 @@
                 <td>ip-10-9-244-1.eu-west-1.compute.internal</td>
                 <td>backend-b654304ce9-d5e12</td>
                 <td>default</td>
-                <td>Fri, 10 Jul 06:01:13</td>
+                <td>Fri, 10 Jul 04:01:13</td>
                 <td>
                   
                     <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
@@ -2449,7 +2449,7 @@
                 <td>ip-10-139-70-16.eu-west-1.compute.internal</td>
                 <td>backend-b654304ce9-fc633</td>
                 <td>default</td>
-                <td>Tue, 7 Jul 03:20:52</td>
+                <td>Tue, 7 Jul 01:20:52</td>
                 <td>
                   
                     <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
@@ -2467,7 +2467,7 @@
                 <td>ip-10-87-167-17.eu-west-1.compute.internal</td>
                 <td>backend-b654304ce9-8e9dc</td>
                 <td>default</td>
-                <td>Tue, 7 Jul 22:55:24</td>
+                <td>Tue, 7 Jul 20:55:24</td>
                 <td>
                   
                     <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
@@ -2485,7 +2485,7 @@
                 <td>ip-10-100-133-4.eu-west-1.compute.internal</td>
                 <td>backend-b654304ce9-8fc6f</td>
                 <td>default</td>
-                <td>Thu, 9 Jul 11:38:15</td>
+                <td>Thu, 9 Jul 09:38:15</td>
                 <td>
                   
                     <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>
@@ -2503,7 +2503,7 @@
                 <td>ip-10-93-23-6.eu-west-1.compute.internal</td>
                 <td>backend-b654304ce9-83111</td>
                 <td>default</td>
-                <td>Fri, 10 Jul 12:49:41</td>
+                <td>Fri, 10 Jul 10:49:41</td>
                 <td>
                   
                     <span class="badge badge-success" title="Deployment is healthy with 10 pods">DeploymentOK</span>

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/rebuy-de/rebuy-go-sdk/v2 v2.4.1-0.20200612124820-6398f0afc167
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0
+	github.com/stretchr/testify v1.5.1
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.2

--- a/go.sum
+++ b/go.sum
@@ -407,6 +407,7 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=

--- a/pkg/collectors/instances.go
+++ b/pkg/collectors/instances.go
@@ -34,11 +34,11 @@ func (i *Instance) WantsShutdown() bool {
 }
 
 func (i *Instance) PendingLifecycleCompletion() bool {
-	return i.HasASGData() && i.ASG.Deleted == true
+	return i.HasASGData() && !i.ASG.Completed
 }
 
 func (i *Instance) HasLifecycleMessage() bool {
-	return i.HasASGData() && i.ASG.Deleted == false
+	return i.HasASGData() && !i.ASG.Deleted
 }
 
 func (i *Instance) HasEC2State(states ...string) bool {

--- a/pkg/collectors/testdata/builder.go
+++ b/pkg/collectors/testdata/builder.go
@@ -25,6 +25,8 @@ const (
 	EC2Terminated   EC2State = "terminated"
 )
 
+var AllEC2States = []EC2State{EC2Missing, EC2Pending, EC2Running, EC2ShuttingDown, EC2Terminated}
+
 type SpotState string
 
 const (
@@ -50,6 +52,8 @@ const (
 	ASGOnlyDeleted   ASGState = "only-deleted"
 	ASGDone          ASGState = "done"
 )
+
+var AllASGStates = []ASGState{ASGMissing, ASGPending, ASGOnlyDeleted, ASGOnlyCompleted, ASGDone}
 
 type InstanceTemplate struct {
 	Name string


### PR DESCRIPTION
> https://jira.rebuy.de/browse/CLOUD-2387

Adds test for the filters that are used in the mainloop. The filters are the most critical part of the main loop, because if they are wrong, the mainloop might shut down the wrong instance.

In this PR I gave [testify](https://github.com/stretchr/testify) a shot. Initially I use if for mocks (see #56), but mocking the thing feels too complicated. The assertion library looks good anyways.

Additionally I had to fix the tests within the Docker build. It failed on Quay, because the time zone there is not `Europe/Berlin`. I had to hack the tests and switch to UTC.

This test already revealed a bug in the filter. It did not actually complete the correct instances so the lifecycle hook always timed out after (`60s`). Now the shutdown is fast again (`20s`).