### PR TITLE
CLOUD-2387 do not complete instances that have running pods

### DIFF
--- a/cmd/inst.go
+++ b/cmd/inst.go
@@ -11,10 +11,11 @@ import (
 )
 
 const (
-	metricMainLoopIterations       = "mainloop_iterations_total"
 	metricMainLoopActions          = "mainloop_actions_total"
 	metricMainLoopDrainDuration    = "mainloop_drain_duration"
+	metricMainLoopIterations       = "mainloop_iterations_total"
 	metricMainLoopPendingInstances = "mainloop_pending_instances"
+	metricMainLoopPodStats         = "mainloop_pod_stats"
 )
 
 type instCacheKey string
@@ -22,11 +23,12 @@ type instCacheKey string
 const instCacheKeyStates instCacheKey = "ec2-instance-state-cache"
 
 func InitIntrumentation(ctx context.Context) context.Context {
-	ctx = instutil.NewCounter(ctx, metricMainLoopIterations)
 	ctx = instutil.NewCounterVec(ctx, metricMainLoopActions, "action")
-	ctx = instutil.NewGauge(ctx, metricMainLoopPendingInstances)
 	ctx = instutil.NewHistogram(ctx, metricMainLoopDrainDuration,
 		instutil.BucketScale(60, 1, 2, 3, 5, 8, 13, 21, 34)...)
+	ctx = instutil.NewCounter(ctx, metricMainLoopIterations)
+	ctx = instutil.NewGauge(ctx, metricMainLoopPendingInstances)
+	ctx = instutil.NewGaugeVec(ctx, metricMainLoopPodStats, "name")
 
 	// Register the already known label values, so Prometheus starts with 0 and
 	// not 1 and properly calculates rates.

--- a/cmd/sorters.go
+++ b/cmd/sorters.go
@@ -22,7 +22,8 @@ func SortPods(pods collectors.Pods) {
 func SelectInstancesThatNeedLifecycleCompletion(instances collectors.Instances) collectors.Instances {
 	return instances.
 		Select(collectors.HasEC2State(ec2.InstanceStateRunning)).
-		Select(collectors.PendingLifecycleCompletion)
+		Select(collectors.PendingLifecycleCompletion).
+		FilterByAllPods(collectors.PodImmuneToEviction)
 }
 
 func SelectInstancesThanNeedLifecycleDeletion(instances collectors.Instances) collectors.Instances {
@@ -31,3 +32,18 @@ func SelectInstancesThanNeedLifecycleDeletion(instances collectors.Instances) co
 		Filter(collectors.PendingLifecycleCompletion).
 		Select(collectors.HasLifecycleMessage)
 }
+
+func SelectInstancesThatWantShutdown(instances collectors.Instances) collectors.Instances {
+	return instances.
+		Select(collectors.HasEC2Data).
+		Select(collectors.HasEC2State(ec2.InstanceStateRunning)).
+		Select(collectors.PendingLifecycleCompletion)
+}
+
+//func SelectPodsThatNeedEviction(pods collectors.Pods) collectors.Pods {
+//	return pods
+//}
+//
+//func SelectPodsThatAreImminueToEviction(pods collectors.Pods) collectors.Pods {
+//	return pods //.Select(collectors.PodImmuneToEviction)
+//}

--- a/cmd/sorters_test.go
+++ b/cmd/sorters_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,23 +26,76 @@ func TestSelectInstancesThatNeedLifecycleCompletion(t *testing.T) {
 		}
 	}
 
-	instances, _ := collectors.Combine(b.Build())
+	t.Run("StatesOnEmptyInstances", func(t *testing.T) {
+		instances, _ := collectors.Combine(b.Build())
 
-	result := SelectInstancesThatNeedLifecycleCompletion(instances)
-	assert.Len(t, result, 2)
-	names := []string{}
+		result := SelectInstancesThatNeedLifecycleCompletion(instances)
+		assert.Len(t, result, 2)
+		names := []string{}
 
-	for _, instance := range result {
-		assert.Equal(t, instance.InstanceID, instance.EC2.InstanceID, "should have EC2 data")
-		assert.Equal(t, instance.InstanceID, instance.ASG.ID, "should have ASG data")
-		assert.Equal(t, instance.EC2.State, "running", "should be in running state")
-		assert.False(t, instance.ASG.Completed, "should not be completed yet")
+		for _, instance := range result {
+			assert.Equal(t, instance.InstanceID, instance.EC2.InstanceID, "should have EC2 data")
+			assert.Equal(t, instance.InstanceID, instance.ASG.ID, "should have ASG data")
+			assert.Equal(t, instance.EC2.State, "running", "should be in running state")
+			assert.False(t, instance.ASG.Completed, "should not be completed yet")
 
-		names = append(names, instance.EC2.InstanceName)
-	}
+			for _, pod := range instance.Pods {
+				assert.True(t, pod.ImmuneToEviction(), "there should only be immune pods left")
+				assert.NotContains(t, []string{"Deployment", "StatefulSet", "Job", "ReplicaSet"},
+					pod.OwnerKind, "only DaemonSets and Nodes are allowed")
+				assert.False(t, pod.OwnerReady.CanDecrement, "immune pods are not ready for decrement")
+			}
 
-	assert.Contains(t, names, "running_only-deleted")
-	assert.Contains(t, names, "running_pending")
+			names = append(names, instance.EC2.InstanceName)
+		}
+
+		assert.Contains(t, names, "running_only-deleted")
+		assert.Contains(t, names, "running_pending")
+	})
+
+	t.Run("OnlyImmunePods", func(t *testing.T) {
+		instances, _ := collectors.Combine(b.Build())
+		b.AddWorkload(testdata.PodTemplate{
+			Owner: testdata.OwnerDaemonSet,
+			Name:  "dns",
+
+			TotalReplicas:   math.MaxInt32,
+			UnreadyReplicas: 0,
+		})
+
+		result := SelectInstancesThatNeedLifecycleCompletion(instances)
+		assert.Len(t, result, 2)
+		names := []string{}
+
+		for _, instance := range result {
+			for _, pod := range instance.Pods {
+				assert.True(t, pod.ImmuneToEviction(), "there should only be immune pods left")
+				assert.NotContains(t, []string{"Deployment", "StatefulSet", "Job", "ReplicaSet"},
+					pod.OwnerKind, "only DaemonSets and Nodes are allowed")
+				assert.False(t, pod.OwnerReady.CanDecrement, "immune pods are not ready for decrement")
+			}
+
+			names = append(names, instance.EC2.InstanceName)
+		}
+
+		assert.Contains(t, names, "running_only-deleted")
+		assert.Contains(t, names, "running_pending")
+	})
+
+	t.Run("NoCompletionWithPods", func(t *testing.T) {
+		b.AddWorkload(testdata.PodTemplate{
+			Owner: testdata.OwnerDeployment,
+			Name:  "worker",
+
+			TotalReplicas:   math.MaxInt32,
+			UnreadyReplicas: 0,
+		})
+
+		instances, _ := collectors.Combine(b.Build())
+
+		result := SelectInstancesThatNeedLifecycleCompletion(instances)
+		assert.Len(t, result, 0)
+	})
 }
 
 func TestSelectInstancesThatNeedLifecycleDeletion(t *testing.T) {
@@ -69,4 +123,37 @@ func TestSelectInstancesThatNeedLifecycleDeletion(t *testing.T) {
 		assert.True(t, instance.ASG.Completed, "should be completed")
 		assert.False(t, instance.ASG.Deleted, "should not be deleted")
 	}
+}
+
+func TestSelectInstancesThatWantShutdown(t *testing.T) {
+	b := testdata.NewBuilder()
+
+	for _, ec2State := range testdata.AllEC2States {
+		for _, asgState := range testdata.AllASGStates {
+			b.AddInstance(1, testdata.InstanceTemplate{
+				ASG:  asgState,
+				EC2:  ec2State,
+				Spot: testdata.SpotRunning,
+				Node: testdata.NodeSchedulable,
+				Name: fmt.Sprintf("%v_%v", ec2State, asgState),
+			})
+		}
+	}
+
+	instances, _ := collectors.Combine(b.Build())
+	result := SelectInstancesThatWantShutdown(instances)
+	assert.Len(t, result, 2)
+	names := []string{}
+
+	for _, instance := range result {
+		assert.Equal(t, instance.InstanceID, instance.EC2.InstanceID, "should have EC2 data")
+		assert.Equal(t, instance.InstanceID, instance.ASG.ID, "should have ASG data")
+		assert.Equal(t, instance.EC2.State, "running", "should be in running state")
+		assert.False(t, instance.ASG.Completed, "should not be completed yet")
+
+		names = append(names, instance.EC2.InstanceName)
+	}
+
+	assert.Contains(t, names, "running_pending")
+	assert.Contains(t, names, "running_only-deleted")
 }

--- a/pkg/collectors/instances.go
+++ b/pkg/collectors/instances.go
@@ -116,3 +116,29 @@ func (instances Instances) Filter(selector Selector) Instances {
 	}
 	return result
 }
+
+// FilterByAnyPod returns a subset of the instances based on the Pod selector.
+// The subset only contains instances that do not contain a single Pod which
+// matches the given selector.
+func (instances Instances) FilterByAnyPod(selector PodSelector) Instances {
+	result := Instances{}
+	for _, i := range instances {
+		if len(i.Pods.Select(selector)) == 0 {
+			result = append(result, i)
+		}
+	}
+	return result
+}
+
+// FilterByAllPods returns a subset of the instances based on the Pod
+// selector. The subset only contains instances that only contain Pods which
+// matche the given selector.
+func (instances Instances) FilterByAllPods(selector PodSelector) Instances {
+	result := Instances{}
+	for _, i := range instances {
+		if len(i.Pods.Filter(selector)) == 0 {
+			result = append(result, i)
+		}
+	}
+	return result
+}

--- a/pkg/collectors/pods.go
+++ b/pkg/collectors/pods.go
@@ -78,3 +78,13 @@ func (pods Pods) Split(selector PodSelector) (Pods, Pods) {
 
 	return yay, ney
 }
+
+func (pods Pods) Select(selector PodSelector) Pods {
+	result, _ := pods.Split(selector)
+	return result
+}
+
+func (pods Pods) Filter(selector PodSelector) Pods {
+	_, result := pods.Split(selector)
+	return result
+}


### PR DESCRIPTION
> https://jira.rebuy.de/browse/CLOUD-2387

In theory we could disable the lifecycle hook of the old node-drainer. But we won't do it now.