### PR TITLE
CLOUD-2387 fix lifecycle message deletion

### DIFF
--- a/cmd/sorters.go
+++ b/cmd/sorters.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/rebuy-de/node-drainer/v2/pkg/collectors"
 	"github.com/rebuy-de/node-drainer/v2/pkg/collectors/aws/ec2"
 )
@@ -29,8 +31,9 @@ func SelectInstancesThatNeedLifecycleCompletion(instances collectors.Instances) 
 func SelectInstancesThanNeedLifecycleDeletion(instances collectors.Instances) collectors.Instances {
 	return instances.
 		Filter(collectors.HasEC2Data).
-		Filter(collectors.PendingLifecycleCompletion).
-		Select(collectors.HasLifecycleMessage)
+		Select(collectors.HasASGData).
+		Filter(collectors.LifecycleDeleted).
+		Select(collectors.LifecycleTriggeredOlderThan(time.Hour))
 }
 
 func SelectInstancesThatWantShutdown(instances collectors.Instances) collectors.Instances {

--- a/cmd/sorters_test.go
+++ b/cmd/sorters_test.go
@@ -116,11 +116,11 @@ func TestSelectInstancesThatNeedLifecycleDeletion(t *testing.T) {
 	instances, _ := collectors.Combine(b.Build())
 
 	result := SelectInstancesThanNeedLifecycleDeletion(instances)
-	assert.Len(t, result, 1)
+	assert.Len(t, result, 2)
 
 	for _, instance := range result {
 		assert.Equal(t, instance.EC2.InstanceID, "", "should not have EC2 data")
-		assert.True(t, instance.ASG.Completed, "should be completed")
+		assert.Equal(t, instance.ASG.ID, instance.InstanceID, "should have ASG data")
 		assert.False(t, instance.ASG.Deleted, "should not be deleted")
 	}
 }

--- a/pkg/collectors/instance_select.go
+++ b/pkg/collectors/instance_select.go
@@ -1,10 +1,14 @@
 package collectors
 
+import "time"
+
 // Selector is a function type that defines if an instance should be selected
 // and is used by Select and Filter.
 type Selector func(i *Instance) bool
 
 func HasEC2Data(i *Instance) bool { return i.HasEC2Data() }
+
+func HasASGData(i *Instance) bool { return i.HasASGData() }
 
 func WantsShutdown(i *Instance) bool { return i.WantsShutdown() }
 
@@ -14,4 +18,14 @@ func HasLifecycleMessage(i *Instance) bool { return i.HasLifecycleMessage() }
 
 func HasEC2State(states ...string) Selector {
 	return func(i *Instance) bool { return i.HasEC2State(states...) }
+}
+
+func LifecycleTriggeredOlderThan(age time.Duration) Selector {
+	return func(i *Instance) bool {
+		return time.Since(i.ASG.TriggeredAt) > age
+	}
+}
+
+func LifecycleDeleted(i *Instance) bool {
+	return i.ASG.Deleted
 }


### PR DESCRIPTION
> https://jira.rebuy.de/browse/CLOUD-2387

The message deletion filter was to strict and the node-drainer accumulated around 50 messages over the weekend.