### PR TITLE
CLOUD-2387 improve logging of instance id

### DIFF
--- a/pkg/collectors/aws/asg/asg.go
+++ b/pkg/collectors/aws/asg/asg.go
@@ -52,7 +52,7 @@ type Client interface {
 // Instance is the instance-related data that is retrieved via SQS.
 type Instance struct {
 	// ID is the EC2 Instance ID
-	ID string `logfield:"instance-id"`
+	ID string `logfield:"instance-id,omitempty"`
 
 	// TriggeredAt is the thime then the shutdown was triggered.
 	TriggeredAt time.Time `logfield:"lifecycle-triggered-at"`

--- a/pkg/collectors/aws/ec2/ec2.go
+++ b/pkg/collectors/aws/ec2/ec2.go
@@ -24,9 +24,9 @@ const (
 
 // Instance is the instance-related data that is retrieved via API.
 type Instance struct {
-	InstanceID        string     `logfield:"instance-id"`
+	InstanceID        string     `logfield:"instance-id,omitempty"`
 	InstanceName      string     `logfield:"instance-name"`
-	NodeName          string     `logfield:"node-name"`
+	NodeName          string     `logfield:"node-name,omitempty"`
 	InstanceType      string     `logfield:"instance-type"`
 	AvailabilityZone  string     `logfield:"availability-zone"`
 	InstanceLifecycle string     `logfield:"ec2-instance-lifecycle"`

--- a/pkg/collectors/aws/spot/spot.go
+++ b/pkg/collectors/aws/spot/spot.go
@@ -32,7 +32,7 @@ const (
 
 // Instance is the instance-related data that is retrieved via API.
 type Instance struct {
-	InstanceID       string    `logfield:"instance-id"`
+	InstanceID       string    `logfield:"instance-id,omitempty"`
 	RequestID        string    `logfield:"spot-request-id"`
 	CreateTime       time.Time `logfield:"spot-create-time"`
 	State            string    `logfield:"spot-state"`

--- a/pkg/collectors/kube/node/nodes.go
+++ b/pkg/collectors/kube/node/nodes.go
@@ -18,8 +18,8 @@ import (
 )
 
 type Node struct {
-	InstanceID    string     `logfield:"instance-id"`
-	NodeName      string     `logfield:"node-name"`
+	InstanceID    string     `logfield:"instance-id,omitempty"`
+	NodeName      string     `logfield:"node-name,omitempty"`
 	Unschedulable bool       `logfield:"node-unschedulable"`
 	Taints        []v1.Taint `logfield:"node-taints"`
 }


### PR DESCRIPTION
> https://jira.rebuy.de/browse/CLOUD-2387

The instance ID is often missing in Graylog. I assume this is because the IDs all have the same name `instance-id` and mapstructure is simply overwriting it with an empty value. This might fix it.