### PR TITLE
CLOUD-2387 show pod state changes

### DIFF
--- a/pkg/collectors/aws/asg/asg.go
+++ b/pkg/collectors/aws/asg/asg.go
@@ -226,7 +226,7 @@ func (h *handler) handle(ctx context.Context, message *sqs.Message) error {
 	_, exists := h.cache[id]
 
 	if !exists {
-		logutil.Get(ctx).Info("adding instance to cache")
+		logutil.Get(ctx).Info("received new ASG lifecycle message")
 		h.cache[id] = &cacheItem
 		h.emitter.Emit()
 	}

--- a/pkg/collectors/instances.go
+++ b/pkg/collectors/instances.go
@@ -91,6 +91,15 @@ func (instance Instance) PodStats() InstancePodStats {
 // Instances is a collection of Instance types with some additional functions.
 type Instances []Instance
 
+func (instances Instances) Get(instanceID string) *Instance {
+	for _, instance := range instances {
+		if instance.InstanceID == instanceID {
+			return &instance
+		}
+	}
+	return nil
+}
+
 // Sort returns a sorted list of instances based on the given sorter.
 func (instances Instances) Sort(by InstancesBy) Instances {
 	sort.SliceStable(instances, func(i, j int) bool {

--- a/pkg/collectors/kube/pod/pods.go
+++ b/pkg/collectors/kube/pod/pods.go
@@ -24,10 +24,10 @@ type Pod struct {
 	Namespace string `logfield:"pod-namespace"`
 	NodeName  string `logfield:"node-name"`
 
-	AppName      string `logfield:"-"`
-	AppInstance  string `logfield:"-"`
-	AppVersion   string `logfield:"-"`
-	AppComponent string `logfield:"-"`
+	AppName      string `logfield:"app-name"`
+	AppInstance  string `logfield:"app-instance"`
+	AppVersion   string `logfield:"app-version"`
+	AppComponent string `logfield:"app-component"`
 
 	OwnerKind   string           `logfield:"pod-owner-kind"`
 	OwnerName   string           `logfield:"pod-owner-name"`

--- a/pkg/collectors/pods.go
+++ b/pkg/collectors/pods.go
@@ -8,8 +8,8 @@ import (
 )
 
 type Pod struct {
-	Instance
-	pod.Pod
+	Instance `logfield:",squash"`
+	pod.Pod  `logfield:",squash"`
 }
 
 // Deprecated: Should use filters instead.

--- a/pkg/instutil/transition.go
+++ b/pkg/instutil/transition.go
@@ -1,0 +1,91 @@
+package instutil
+
+import (
+	"context"
+
+	"github.com/rebuy-de/rebuy-go-sdk/v2/pkg/logutil"
+	"github.com/sirupsen/logrus"
+)
+
+type contextKeyTransitionCollector string
+
+type Transition struct {
+	Name     string
+	From, To string
+	Fields   logrus.Fields
+}
+
+func GetTransitionCollector(ctx context.Context, name string) *TransitionCollector {
+	cache, ok := ctx.Value(contextKeyTransitionCollector(name)).(*map[string]string)
+	if !ok {
+		logutil.Get(ctx).Warnf("transition collector with name '%s' not found", name)
+		return nil
+	}
+
+	return &TransitionCollector{
+
+		cache: cache,
+	}
+}
+
+type TransitionCollector struct {
+	cache   *map[string]string
+	changes []Transition
+}
+
+func NewTransitionCollector(ctx context.Context, name string) context.Context {
+	cache := map[string]string{}
+	return context.WithValue(ctx, contextKeyTransitionCollector(name), &cache)
+}
+
+func (c *TransitionCollector) Observe(name string, state string, fields logrus.Fields) {
+	if c == nil {
+		return
+	}
+
+	c.changes = append(c.changes, Transition{
+		Name:   name,
+		To:     state,
+		Fields: fields,
+	})
+}
+
+func (c *TransitionCollector) Finish() []Transition {
+	result := []Transition{}
+
+	if c == nil {
+		return result
+	}
+
+	observed := map[string]struct{}{}
+
+	for _, change := range c.changes {
+		from := (*c.cache)[change.Name]
+		(*c.cache)[change.Name] = change.To
+		observed[change.Name] = struct{}{}
+
+		if from == change.To {
+			continue
+		}
+
+		change.From = from
+		result = append(result, change)
+	}
+
+	for name, value := range *c.cache {
+		_, found := observed[name]
+		if found {
+			continue
+		}
+
+		result = append(result, Transition{
+			Name: name,
+			From: value,
+		})
+
+		delete(*c.cache, name)
+
+	}
+
+	return result
+}

--- a/pkg/instutil/transition_test.go
+++ b/pkg/instutil/transition_test.go
@@ -1,0 +1,84 @@
+package instutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransitionCollector(t *testing.T) {
+	ctx := context.Background()
+	ctx = NewTransitionCollector(ctx, "test-a")
+	ctx = NewTransitionCollector(ctx, "test-b")
+
+	// Note: The sub tests depend on each other.
+
+	t.Run("AddInitial", func(t *testing.T) {
+		tc := GetTransitionCollector(ctx, "test-a")
+		tc.Observe("i-001", "pending", nil)
+		tc.Observe("i-002", "running", nil)
+		tc.Observe("i-003", "terminated", nil)
+		result := tc.Finish()
+
+		require.Len(t, result, 3)
+
+		assert.Equal(t, Transition{Name: "i-001", From: "", To: "pending"}, result[0])
+		assert.Equal(t, Transition{Name: "i-002", From: "", To: "running"}, result[1])
+		assert.Equal(t, Transition{Name: "i-003", From: "", To: "terminated"}, result[2])
+	})
+
+	t.Run("ChangeSingleState", func(t *testing.T) {
+		tc := GetTransitionCollector(ctx, "test-a")
+		tc.Observe("i-001", "running", nil)
+		tc.Observe("i-002", "running", nil)
+		tc.Observe("i-003", "terminated", nil)
+		result := tc.Finish()
+
+		require.Len(t, result, 1)
+
+		assert.Equal(t, Transition{Name: "i-001", From: "pending", To: "running"}, result[0])
+	})
+
+	t.Run("RemoveState", func(t *testing.T) {
+		tc := GetTransitionCollector(ctx, "test-a")
+		tc.Observe("i-001", "running", nil)
+		tc.Observe("i-002", "running", nil)
+		result := tc.Finish()
+
+		require.Len(t, result, 1)
+
+		assert.Equal(t, Transition{Name: "i-003", From: "terminated", To: ""}, result[0])
+	})
+
+	t.Run("EmptyStateRemovesToo", func(t *testing.T) {
+		tc := GetTransitionCollector(ctx, "test-a")
+		tc.Observe("i-001", "running", nil)
+		tc.Observe("i-002", "", nil)
+		result := tc.Finish()
+
+		require.Len(t, result, 1)
+
+		assert.Equal(t, Transition{Name: "i-002", From: "running", To: ""}, result[0])
+	})
+
+	t.Run("CachedToNotInterfere", func(t *testing.T) {
+		tc := GetTransitionCollector(ctx, "test-b")
+		result := tc.Finish()
+
+		// The `test-a` cache still have states in it. Therefore it would want
+		// to remove it, when they access the same cache.
+		require.Len(t, result, 0)
+	})
+
+	t.Run("MissingShouldNotCrash", func(t *testing.T) {
+		tc := GetTransitionCollector(ctx, "missing")
+		tc.Observe("i-001", "pending", nil)
+		tc.Observe("i-002", "running", nil)
+		tc.Observe("i-003", "terminated", nil)
+		result := tc.Finish()
+
+		require.Len(t, result, 0)
+	})
+}


### PR DESCRIPTION
> https://jira.rebuy.de/browse/CLOUD-2387

This rounds up the logging.

### State Change Logs 

* Query: `source:node\-drainer\-v2\-* AND level:<7 AND instance-id:i\-0e73a1fdd4e86b94c`
* Link: [Graylog](https://graylog.production.rebuy.cloud/streams/5bdc242178cf3e0001a60dcd/search?rangetype=absolute&fields=instance-id%2Cmessage%2Cpod-name&width=1278&highlightMessage=&from=2020-08-12T11%3A50%3A18.000Z&timerange-absolute-from=2020-08-12%2013%3A50%3A18&to=2020-08-12T11%3A56%3A38.000Z&timerange-absolute-to=2020-08-12%2013%3A56%3A38&q=source%3Anode%5C-drainer%5C-v2%5C-*%20AND%20level%3A%3C7%20AND%20instance-id%3Ai%5C-0e73a1fdd4e86b94c)
* Screenshot: ![image](https://user-images.githubusercontent.com/1698599/90012735-421a7980-dca4-11ea-8976-13bee7e7cafe.png)

