### PR TITLE
Fix static credential fallback

### DIFF
--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -55,7 +55,11 @@ func (r *Runner) Run(ctx context.Context, cmd *cobra.Command, args []string) {
 		err        error
 	)
 
-	if r.vault == (vaultutil.Params{}) {
+	if r.vault == (vaultutil.Params{
+		Role:          cmdutil.Name,
+		AWSRole:       cmdutil.Name,
+		AWSEnginePath: "aws",
+	}) {
 		// Fallback to generic AWS session generation, if no vault flag was provided.
 		awsSession, err = session.NewSessionWithOptions(session.Options{
 			SharedConfigState: session.SharedConfigEnable,


### PR DESCRIPTION
The fallback to static credentials didn't work because `r.vault` is not an empty struct since it is filled with defaults. This change makes it work again.