### PR TITLE
fix panic

### DIFF
--- a/pkg/collectors/aws/asg/asg.go
+++ b/pkg/collectors/aws/asg/asg.go
@@ -168,7 +168,7 @@ func (h *handler) runOnce(ctx context.Context) error {
 		WaitTimeSeconds:       10,
 	})
 	if err != nil {
-		var ce smithy.CanceledError
+		var ce *smithy.CanceledError
 		if errors.As(err, &ce) {
 			// This is a graceful shutdown, triggered by the context
 			// and not an actual error.


### PR DESCRIPTION
```
panic: errors: *target must be interface or implement error

goroutine 96 [running]:
errors.As({0x2b5b900, 0xc002ef2600}, {0x24ed6e0, 0xc000792a20?})
	/usr/local/go/src/errors/wrap.go:89 +0x3df
github.com/pkg/errors.As(...)
	/build/vendor/github.com/pkg/errors/go113.go:31
github.com/rebuy-de/node-drainer/v2/pkg/collectors/aws/asg.(*handler).runOnce(0xc00064c400, {0x2b857b8, 0xc00051b3e0})
	/build/pkg/collectors/aws/asg/asg.go:172 +0x1e5
github.com/rebuy-de/node-drainer/v2/pkg/collectors/aws/asg.(*handler).Run(0xc00064c400, {0x2b85710?, 0xc00064c440?})
	/build/pkg/collectors/aws/asg/asg.go:136 +0xae
github.com/rebuy-de/node-drainer/v2/cmd.(*Runner).Run.func3()
	/build/cmd/runner.go:107 +0x2a
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/build/vendor/golang.org/x/sync/errgroup/errgroup.go:57 +0x67
created by golang.org/x/sync/errgroup.(*Group).Go
	/build/vendor/golang.org/x/sync/errgroup/errgroup.go:54 +0x8d
```